### PR TITLE
feat: add account balance collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4328,6 +4328,7 @@ dependencies = [
  "solana-pubkey",
  "solana-rent",
  "solana-rent-debits",
+ "solana-reserved-account-keys",
  "solana-sbpf",
  "solana-sdk",
  "solana-sdk-ids",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ solana-program-runtime = { version = "=2.2.1", features = ["metrics"] }
 solana-pubkey = { version = "=2.2.1" }
 solana-rent = { version = "=2.2.1" }
 solana-rent-debits = { version = "=2.2.1" }
+solana-reserved-account-keys = { version = "=2.2.1" }
 solana-sdk = { version = "=2.2.1" }
 solana-sdk-ids = { version = "=2.2.1" }
 solana-svm-rent-collector = { version = "=2.2.1" }

--- a/src/account_loader.rs
+++ b/src/account_loader.rs
@@ -118,9 +118,12 @@ pub struct FeesOnlyTransaction {
     pub fee_details: FeeDetails,
 }
 
+/// Two lists of accounts' balances before and after the transaction
 #[derive(Default)]
 pub struct AccountsBalances {
+    /// List of balances before the transaction
     pub pre: Vec<u64>,
+    /// List of balances after the transaction
     pub post: Vec<u64>,
 }
 

--- a/src/account_loader.rs
+++ b/src/account_loader.rs
@@ -118,12 +118,19 @@ pub struct FeesOnlyTransaction {
     pub fee_details: FeeDetails,
 }
 
+#[derive(Default)]
+pub struct AccountsBalances {
+    pub pre: Vec<u64>,
+    pub post: Vec<u64>,
+}
+
 #[cfg_attr(feature = "dev-context-only-utils", derive(Clone))]
 pub(crate) struct AccountLoader<'a, CB: TransactionProcessingCallback> {
     account_cache: AHashMap<Pubkey, AccountSharedData>,
     callbacks: &'a CB,
     pub(crate) feature_set: Arc<FeatureSet>,
 }
+
 impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
     pub(crate) fn new_with_account_cache_capacity(
         account_overrides: Option<&'a AccountOverrides>,

--- a/src/transaction_processor.rs
+++ b/src/transaction_processor.rs
@@ -170,7 +170,7 @@ impl Default for TransactionProcessingEnvironment<'_> {
 )]
 pub struct TransactionBatchProcessor<FG: ForkGraph> {
     /// Bank slot (i.e. block)
-    slot: Slot,
+    pub slot: Slot,
 
     /// Bank epoch
     epoch: Epoch,
@@ -319,7 +319,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .map(|cache| cache.get_environments_for_epoch(epoch))
     }
 
-    pub fn sysvar_cache(&self) -> RwLockReadGuard<SysvarCache> {
+    pub fn sysvar_cache(&self) -> RwLockReadGuard<'_, SysvarCache> {
         self.sysvar_cache.read().unwrap()
     }
 
@@ -1228,10 +1228,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn writable_sysvar_cache(&self) -> &RwLock<SysvarCache> {
         &self.sysvar_cache
-    }
-
-    pub fn set_slot(&mut self, slot: Slot) {
-        self.slot = slot
     }
 }
 

--- a/src/transaction_processor.rs
+++ b/src/transaction_processor.rs
@@ -362,7 +362,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         });
 
         // Optimization, as we need to record account balances before
-        // and after transaction, we do it write during the load->execute
+        // and after transaction, we do it during the load->execute
         // stage, as we already have an access to all of the accounts
         let mut balances = AccountsBalances::default();
 

--- a/src/transaction_processor.rs
+++ b/src/transaction_processor.rs
@@ -129,6 +129,7 @@ pub struct TransactionProcessingConfig<'a> {
 }
 
 /// Runtime environment for transaction batch processing.
+#[derive(Clone)]
 pub struct TransactionProcessingEnvironment<'a> {
     /// The blockhash to use for the transaction batch.
     pub blockhash: Hash,


### PR DESCRIPTION
This optimization collects pre and post account balances during accounts load, thus avoiding loading those same accounts before and after transaction execution