### PR TITLE
Fix writable account failure logs

### DIFF
--- a/svm/src/access_permissions.rs
+++ b/svm/src/access_permissions.rs
@@ -63,8 +63,12 @@ impl ExecutedTransaction {
             self.execution_details.status = Err(TransactionError::InvalidWritableAccount);
             let logs = self.execution_details.log_messages.get_or_insert_default();
             logs.push(format!(
-                "Program log: Account {i}:{offender} was illegally used as writeable"
+                "Program log: Account {i}: {offender} was illegally used as writeable"
             ));
+            logs.push(
+                "Program Magic11111111111111111111111111111111111111 failed: InvalidWritableAccount"
+                    .to_string(),
+            );
         }
     }
 }
@@ -191,6 +195,16 @@ mod tests {
         assert_eq!(
             tx.execution_details.status,
             Err(TransactionError::InvalidWritableAccount)
+        );
+        assert_eq!(
+            tx.execution_details.log_messages.as_ref().unwrap(),
+            &vec![
+                format!(
+                    "Program log: Account 1: {writable} was illegally used as writeable"
+                ),
+                "Program Magic11111111111111111111111111111111111111 failed: InvalidWritableAccount"
+                    .to_string(),
+            ]
         );
     }
 

--- a/svm/src/access_permissions.rs
+++ b/svm/src/access_permissions.rs
@@ -63,7 +63,7 @@ impl ExecutedTransaction {
             self.execution_details.status = Err(TransactionError::InvalidWritableAccount);
             let logs = self.execution_details.log_messages.get_or_insert_default();
             logs.push(format!(
-                "Program log: Account {i}: {offender} was illegally used as writeable"
+                "Program log: Account {i}: {offender} was illegally used as writable"
             ));
             logs.push(
                 "Program Magic11111111111111111111111111111111111111 failed: InvalidWritableAccount"
@@ -200,7 +200,7 @@ mod tests {
             tx.execution_details.log_messages.as_ref().unwrap(),
             &vec![
                 format!(
-                    "Program log: Account 1: {writable} was illegally used as writeable"
+                    "Program log: Account 1: {writable} was illegally used as writable"
                 ),
                 "Program Magic11111111111111111111111111111111111111 failed: InvalidWritableAccount"
                     .to_string(),


### PR DESCRIPTION
## Summary

- Restore the explicit `InvalidWritableAccount` program failure log for writable-account access violations (explorer and SDKs otherwise incorrectly show this txs as succesful)
- Small NIT: Add a missing space after the account index in the writable-account diagnostic log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error/log output for account access validation to include account-specific illegality messages and an additional program-failure log line for clearer diagnostics.

* **Tests**
  * Expanded tests to assert the exact execution log messages and formatting for access denial scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-svm/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->