### PR TITLE
fix(svm): allow post-action executor after clone

### DIFF
--- a/svm/src/access_permissions.rs
+++ b/svm/src/access_permissions.rs
@@ -37,7 +37,15 @@ impl ExecutedTransaction {
             return;
         }
         let accounts = &self.loaded_transaction.accounts;
-        let privileged_access = accounts
+        let mut access = PrivilegedAccess::None;
+        if let Some((pk, payer)) = accounts.first() {
+            if payer.privileged() {
+                access = privileged_access(message);
+            }
+            if access == PrivilegedAccess::Full {
+                return;
+            }
+            if !access.allows_fee_payer_write() && !payer.delegated() && payer.lamports_changed() {
             .first()
             .map(|(_, payer)| {
                 if payer.privileged() {

--- a/svm/src/access_permissions.rs
+++ b/svm/src/access_permissions.rs
@@ -36,11 +36,24 @@ impl ExecutedTransaction {
             return;
         }
         let accounts = &self.loaded_transaction.accounts;
+        let privileged_access = accounts
+            .first()
+            .map(|(_, payer)| {
+                if payer.privileged() {
+                    privileged_access(message)
+                } else {
+                    PrivilegedAccess::None
+                }
+            })
+            .unwrap_or_default();
         if let Some((pk, payer)) = accounts.first() {
-            if payer.privileged() && has_privileged_access(message) {
+            if privileged_access == PrivilegedAccess::Full {
                 return;
             }
-            if !payer.delegated() && payer.lamports_changed() {
+            if !privileged_access.allows_fee_payer_write()
+                && !payer.delegated()
+                && payer.lamports_changed()
+            {
                 self.execution_details.status = Err(TransactionError::InvalidAccountForFee);
                 let logs = self.execution_details.log_messages.get_or_insert_default();
                 logs.push(format!(
@@ -58,7 +71,10 @@ impl ExecutedTransaction {
         // Skip the fee payer (index 0), as its writability is validated elsewhere.
         for (i, (pk, acc)) in accounts.iter().enumerate().skip(1) {
             // Enforce that any account intended to be writable must be a delegated account.
-            if message.is_writable(i) && !is_mutable(acc) {
+            if message.is_writable(i)
+                && !is_mutable(acc)
+                && !privileged_access.allows_account_write(i)
+            {
                 offender.replace((i, pk));
                 break;
             }
@@ -77,16 +93,43 @@ impl ExecutedTransaction {
     }
 }
 
-fn has_privileged_access(message: &impl SVMMessage) -> bool {
+#[derive(Default, PartialEq)]
+enum PrivilegedAccess {
+    #[default]
+    None,
+    Full,
+    CloneWithPostDelegationActionExecutor {
+        clone_accounts: Vec<usize>,
+    },
+}
+
+impl PrivilegedAccess {
+    fn allows_fee_payer_write(&self) -> bool {
+        matches!(
+            self,
+            PrivilegedAccess::Full | PrivilegedAccess::CloneWithPostDelegationActionExecutor { .. }
+        )
+    }
+
+    fn allows_account_write(&self, index: usize) -> bool {
+        match self {
+            PrivilegedAccess::CloneWithPostDelegationActionExecutor { clone_accounts } => {
+                clone_accounts.contains(&index)
+            }
+            PrivilegedAccess::Full => true,
+            PrivilegedAccess::None => false,
+        }
+    }
+}
+
+fn privileged_access(message: &impl SVMMessage) -> PrivilegedAccess {
     let instructions = message.instructions_iter().collect::<Vec<_>>();
     if instructions.len() == 2
         && instruction_program_id(message, &instructions[0]) == Some(MAGIC_PROGRAM_ID)
         && instruction_program_id(message, &instructions[1])
             == Some(POST_DELEGATION_ACTION_EXECUTOR_PROGRAM_ID)
     {
-        return instruction_discriminant(&instructions[0]).is_some_and(|d| {
-            d == CLONE_ACCOUNT_DISCRIMINANT || d == CLONE_ACCOUNT_CONTINUE_DISCRIMINANT
-        });
+        return clone_with_post_delegation_action_executor_access(&instructions);
     }
 
     for instruction in instructions {
@@ -94,21 +137,39 @@ fn has_privileged_access(message: &impl SVMMessage) -> bool {
             .account_keys()
             .get(instruction.program_id_index as usize)
         else {
-            return false;
+            return PrivilegedAccess::None;
         };
         if *program == loader_v4::ID {
             continue;
         }
         if *program != MAGIC_PROGRAM_ID {
-            return false;
+            return PrivilegedAccess::None;
         }
 
         let discriminant = instruction_discriminant(&instruction).unwrap_or(u32::MAX);
         if !PRIVILEGED_MAGIC_DISCRIMINANTS.contains(&discriminant) {
-            return false;
+            return PrivilegedAccess::None;
         }
     }
-    true
+    PrivilegedAccess::Full
+}
+
+fn clone_with_post_delegation_action_executor_access(
+    instructions: &[SVMInstruction<'_>],
+) -> PrivilegedAccess {
+    if !instruction_discriminant(&instructions[0]).is_some_and(|d| {
+        d == CLONE_ACCOUNT_DISCRIMINANT || d == CLONE_ACCOUNT_CONTINUE_DISCRIMINANT
+    }) {
+        return PrivilegedAccess::None;
+    }
+
+    PrivilegedAccess::CloneWithPostDelegationActionExecutor {
+        clone_accounts: instructions[0]
+            .accounts
+            .iter()
+            .map(|account_index| *account_index as usize)
+            .collect(),
+    }
 }
 
 fn instruction_program_id(
@@ -154,13 +215,28 @@ mod tests {
     }
 
     fn executed_transaction(payer: Pubkey, writable: Pubkey) -> ExecutedTransaction {
+        executed_transaction_with_writable_accounts(payer, vec![writable])
+    }
+
+    fn executed_transaction_with_writable_accounts(
+        payer: Pubkey,
+        writable_accounts: Vec<Pubkey>,
+    ) -> ExecutedTransaction {
+        let mut accounts = vec![(payer, privileged_account())];
+        accounts.extend(
+            writable_accounts
+                .into_iter()
+                .map(|pubkey| (pubkey, AccountSharedData::default())),
+        );
+        accounts.push((MAGIC_PROGRAM_ID, AccountSharedData::default()));
+        accounts.push((
+            POST_DELEGATION_ACTION_EXECUTOR_PROGRAM_ID,
+            AccountSharedData::default(),
+        ));
+
         ExecutedTransaction {
             loaded_transaction: LoadedTransaction {
-                accounts: vec![
-                    (payer, privileged_account()),
-                    (writable, AccountSharedData::default()),
-                    (MAGIC_PROGRAM_ID, AccountSharedData::default()),
-                ],
+                accounts,
                 program_indices: vec![],
                 fee_details: FeeDetails::default(),
                 rollback_accounts: RollbackAccounts::default(),
@@ -200,8 +276,23 @@ mod tests {
     }
 
     fn message_with_programs(instructions: Vec<(Pubkey, Vec<u8>)>) -> SanitizedMessage {
-        let mut account_keys = vec![Pubkey::new_unique(), Pubkey::new_unique()];
-        account_keys.extend(instructions.iter().map(|(program, _)| *program));
+        message_with_program_accounts(
+            1,
+            instructions
+                .into_iter()
+                .map(|(program, data)| (program, data, vec![0, 1]))
+                .collect(),
+        )
+    }
+
+    fn message_with_program_accounts(
+        num_writable_accounts: u8,
+        instructions: Vec<(Pubkey, Vec<u8>, Vec<u8>)>,
+    ) -> SanitizedMessage {
+        let mut account_keys = vec![Pubkey::new_unique()];
+        account_keys.extend((0..num_writable_accounts).map(|_| Pubkey::new_unique()));
+        let program_id_start = account_keys.len();
+        account_keys.extend(instructions.iter().map(|(program, _, _)| *program));
 
         SanitizedMessage::Legacy(LegacyMessage::new(
             Message {
@@ -214,9 +305,9 @@ mod tests {
                 instructions: instructions
                     .into_iter()
                     .enumerate()
-                    .map(|(idx, (_, data))| CompiledInstruction {
-                        program_id_index: (idx + 2) as u8,
-                        accounts: vec![1],
+                    .map(|(idx, (_, data, accounts))| CompiledInstruction {
+                        program_id_index: (program_id_start + idx) as u8,
+                        accounts,
                         data,
                     })
                     .collect(),
@@ -314,6 +405,47 @@ mod tests {
         assert_eq!(
             tx.execution_details.status,
             Err(TransactionError::InvalidWritableAccount)
+        );
+    }
+
+    #[test]
+    fn privileged_payer_rejects_post_delegation_action_executor_with_extra_writable_account() {
+        let payer = Pubkey::new_unique();
+        let writable = Pubkey::new_unique();
+        let extra_writable = Pubkey::new_unique();
+        let mut tx =
+            executed_transaction_with_writable_accounts(payer, vec![writable, extra_writable]);
+        let message = message_with_program_accounts(
+            2,
+            vec![
+                (
+                    MAGIC_PROGRAM_ID,
+                    CLONE_ACCOUNT_DISCRIMINANT.to_le_bytes().to_vec(),
+                    vec![0, 1],
+                ),
+                (
+                    POST_DELEGATION_ACTION_EXECUTOR_PROGRAM_ID,
+                    vec![],
+                    vec![0, 1, 2],
+                ),
+            ],
+        );
+
+        tx.validate_accounts_access(&message);
+
+        assert_eq!(
+            tx.execution_details.status,
+            Err(TransactionError::InvalidWritableAccount)
+        );
+        assert_eq!(
+            tx.execution_details.log_messages.as_ref().unwrap(),
+            &vec![
+                format!(
+                    "Program log: Account 2: {extra_writable} was illegally used as writable"
+                ),
+                "Program Magic11111111111111111111111111111111111111 failed: InvalidWritableAccount"
+                    .to_string(),
+            ]
         );
     }
 

--- a/svm/src/access_permissions.rs
+++ b/svm/src/access_permissions.rs
@@ -46,23 +46,6 @@ impl ExecutedTransaction {
                 return;
             }
             if !access.allows_fee_payer_write() && !payer.delegated() && payer.lamports_changed() {
-            .first()
-            .map(|(_, payer)| {
-                if payer.privileged() {
-                    privileged_access(message)
-                } else {
-                    PrivilegedAccess::None
-                }
-            })
-            .unwrap_or_default();
-        if let Some((pk, payer)) = accounts.first() {
-            if privileged_access == PrivilegedAccess::Full {
-                return;
-            }
-            if !privileged_access.allows_fee_payer_write()
-                && !payer.delegated()
-                && payer.lamports_changed()
-            {
                 self.execution_details.status = Err(TransactionError::InvalidAccountForFee);
                 let logs = self.execution_details.log_messages.get_or_insert_default();
                 logs.push(format!(
@@ -80,10 +63,7 @@ impl ExecutedTransaction {
         // Skip the fee payer (index 0), as its writability is validated elsewhere.
         for (i, (pk, acc)) in accounts.iter().enumerate().skip(1) {
             // Enforce that any account intended to be writable must be a delegated account.
-            if message.is_writable(i)
-                && !is_mutable(acc)
-                && !privileged_access.allows_account_write(i)
-            {
+            if message.is_writable(i) && !is_mutable(acc) && !access.allows_account_write(i) {
                 offender.replace((i, pk));
                 break;
             }
@@ -102,14 +82,11 @@ impl ExecutedTransaction {
     }
 }
 
-#[derive(Default, PartialEq)]
+#[derive(PartialEq)]
 enum PrivilegedAccess {
-    #[default]
     None,
     Full,
-    CloneWithPostDelegationActionExecutor {
-        cloned_account: usize,
-    },
+    CloneWithPostDelegationActionExecutor { cloned_account: usize },
 }
 
 impl PrivilegedAccess {
@@ -141,12 +118,6 @@ fn privileged_access(message: &impl SVMMessage) -> PrivilegedAccess {
     }
 
     for (program, instruction) in message.program_instructions_iter() {
-        let Some(program) = message
-            .account_keys()
-            .get(instruction.program_id_index as usize)
-        else {
-            return PrivilegedAccess::None;
-        };
         if *program == loader_v4::ID {
             continue;
         }
@@ -202,16 +173,6 @@ fn clone_with_post_delegation_action_executor_access(
     PrivilegedAccess::CloneWithPostDelegationActionExecutor {
         cloned_account: cloned_account as usize,
     }
-}
-
-fn instruction_program_id(
-    message: &impl SVMMessage,
-    instruction: &SVMInstruction<'_>,
-) -> Option<Pubkey> {
-    message
-        .account_keys()
-        .get(instruction.program_id_index as usize)
-        .copied()
 }
 
 fn instruction_discriminant(instruction: &SVMInstruction<'_>) -> Option<u32> {

--- a/svm/src/access_permissions.rs
+++ b/svm/src/access_permissions.rs
@@ -132,13 +132,12 @@ impl PrivilegedAccess {
 }
 
 fn privileged_access(message: &impl SVMMessage) -> PrivilegedAccess {
-    let instructions = message.instructions_iter().collect::<Vec<_>>();
-    if instructions.len() == 2
-        && instruction_program_id(message, &instructions[0]) == Some(MAGIC_PROGRAM_ID)
-        && instruction_program_id(message, &instructions[1])
-            == Some(POST_DELEGATION_ACTION_EXECUTOR_PROGRAM_ID)
-    {
-        return clone_with_post_delegation_action_executor_access(&instructions);
+    let is_post_action = message
+        .program_instructions_iter()
+        .zip(&[MAGIC_PROGRAM_ID, POST_DELEGATION_ACTION_EXECUTOR_PROGRAM_ID])
+        .all(|(ix, prog)| ix.0 == prog);
+    if message.num_instructions() == 2 && is_post_action {
+        return clone_with_post_delegation_action_executor_access(message);
     }
 
     for (program, instruction) in message.program_instructions_iter() {

--- a/svm/src/access_permissions.rs
+++ b/svm/src/access_permissions.rs
@@ -164,26 +164,38 @@ fn privileged_access(message: &impl SVMMessage) -> PrivilegedAccess {
 }
 
 fn clone_with_post_delegation_action_executor_access(
-    instructions: &[SVMInstruction<'_>],
+    message: &impl SVMMessage,
 ) -> PrivilegedAccess {
-    if !instruction_discriminant(&instructions[0]).is_some_and(|d| {
-        d == CLONE_ACCOUNT_DISCRIMINANT || d == CLONE_ACCOUNT_CONTINUE_DISCRIMINANT
-    }) {
+    let mut instructions = message.instructions_iter();
+    let Some(ix1) = instructions.next() else {
         return PrivilegedAccess::None;
-    }
+    };
+    let Some(ix2) = instructions.next() else {
+        return PrivilegedAccess::None;
+    };
+    const ALLOWED_IXS: [u32; 2] = [
+        CLONE_ACCOUNT_DISCRIMINANT,
+        CLONE_ACCOUNT_CONTINUE_DISCRIMINANT,
+    ];
+    if instruction_discriminant(&ix1)
+        .map(|d| !ALLOWED_IXS.contains(&d))
+        .unwrap_or(true)
+    {
+        return PrivilegedAccess::None;
+    };
 
-    let Some(cloned_account) = instructions[0]
+    let Some(cloned_account) = ix1
         .accounts
         .get(CLONED_ACCOUNT_INSTRUCTION_ACCOUNT_INDEX)
         .copied()
     else {
         return PrivilegedAccess::None;
     };
-    if instructions[1]
+    if ix2
         .accounts
         .get(CLONED_ACCOUNT_INSTRUCTION_ACCOUNT_INDEX)
-        .copied()
-        != Some(cloned_account)
+        .map(|&acc| acc != cloned_account)
+        .unwrap_or(true)
     {
         return PrivilegedAccess::None;
     }

--- a/svm/src/access_permissions.rs
+++ b/svm/src/access_permissions.rs
@@ -13,6 +13,7 @@ const POST_DELEGATION_ACTION_EXECUTOR_PROGRAM_ID: Pubkey =
 const PRIVILEGED_MAGIC_DISCRIMINANTS: [u32; 11] = [0, 8, 9, 16, 17, 18, 19, 20, 21, 22, 24];
 const CLONE_ACCOUNT_DISCRIMINANT: u32 = 16;
 const CLONE_ACCOUNT_CONTINUE_DISCRIMINANT: u32 = 18;
+const CLONED_ACCOUNT_INSTRUCTION_ACCOUNT_INDEX: usize = 1;
 
 // NOTE:
 // this impl is kept separately to simplify synchronization with upstream
@@ -99,7 +100,7 @@ enum PrivilegedAccess {
     None,
     Full,
     CloneWithPostDelegationActionExecutor {
-        clone_accounts: Vec<usize>,
+        cloned_account: usize,
     },
 }
 
@@ -113,8 +114,8 @@ impl PrivilegedAccess {
 
     fn allows_account_write(&self, index: usize) -> bool {
         match self {
-            PrivilegedAccess::CloneWithPostDelegationActionExecutor { clone_accounts } => {
-                clone_accounts.contains(&index)
+            PrivilegedAccess::CloneWithPostDelegationActionExecutor { cloned_account } => {
+                *cloned_account == index
             }
             PrivilegedAccess::Full => true,
             PrivilegedAccess::None => false,
@@ -163,12 +164,24 @@ fn clone_with_post_delegation_action_executor_access(
         return PrivilegedAccess::None;
     }
 
+    let Some(cloned_account) = instructions[0]
+        .accounts
+        .get(CLONED_ACCOUNT_INSTRUCTION_ACCOUNT_INDEX)
+        .copied()
+    else {
+        return PrivilegedAccess::None;
+    };
+    if instructions[1]
+        .accounts
+        .get(CLONED_ACCOUNT_INSTRUCTION_ACCOUNT_INDEX)
+        .copied()
+        != Some(cloned_account)
+    {
+        return PrivilegedAccess::None;
+    }
+
     PrivilegedAccess::CloneWithPostDelegationActionExecutor {
-        clone_accounts: instructions[0]
-            .accounts
-            .iter()
-            .map(|account_index| *account_index as usize)
-            .collect(),
+        cloned_account: cloned_account as usize,
     }
 }
 
@@ -409,7 +422,8 @@ mod tests {
     }
 
     #[test]
-    fn privileged_payer_rejects_post_delegation_action_executor_with_extra_writable_account() {
+    fn privileged_payer_rejects_post_delegation_action_executor_with_extra_clone_writable_account()
+    {
         let payer = Pubkey::new_unique();
         let writable = Pubkey::new_unique();
         let extra_writable = Pubkey::new_unique();
@@ -421,7 +435,7 @@ mod tests {
                 (
                     MAGIC_PROGRAM_ID,
                     CLONE_ACCOUNT_DISCRIMINANT.to_le_bytes().to_vec(),
-                    vec![0, 1],
+                    vec![0, 1, 2],
                 ),
                 (
                     POST_DELEGATION_ACTION_EXECUTOR_PROGRAM_ID,

--- a/svm/src/access_permissions.rs
+++ b/svm/src/access_permissions.rs
@@ -133,7 +133,7 @@ fn privileged_access(message: &impl SVMMessage) -> PrivilegedAccess {
         return clone_with_post_delegation_action_executor_access(&instructions);
     }
 
-    for instruction in instructions {
+    for (program, instruction) in message.program_instructions_iter() {
         let Some(program) = message
             .account_keys()
             .get(instruction.program_id_index as usize)

--- a/svm/src/access_permissions.rs
+++ b/svm/src/access_permissions.rs
@@ -1,14 +1,18 @@
 use solana_account::AccountSharedData;
 use solana_pubkey::Pubkey;
 use solana_sdk_ids::loader_v4;
-use solana_svm_transaction::svm_message::SVMMessage;
+use solana_svm_transaction::{instruction::SVMInstruction, svm_message::SVMMessage};
 use solana_transaction_error::TransactionError;
 
 use crate::transaction_execution_result::ExecutedTransaction;
 
 const MAGIC_PROGRAM_ID: Pubkey =
     Pubkey::from_str_const("Magic11111111111111111111111111111111111111");
+const POST_DELEGATION_ACTION_EXECUTOR_PROGRAM_ID: Pubkey =
+    Pubkey::from_str_const("PostAct111111111111111111111111111111111111");
 const PRIVILEGED_MAGIC_DISCRIMINANTS: [u32; 11] = [0, 8, 9, 16, 17, 18, 19, 20, 21, 22, 24];
+const CLONE_ACCOUNT_DISCRIMINANT: u32 = 16;
+const CLONE_ACCOUNT_CONTINUE_DISCRIMINANT: u32 = 18;
 
 // NOTE:
 // this impl is kept separately to simplify synchronization with upstream
@@ -74,7 +78,18 @@ impl ExecutedTransaction {
 }
 
 fn has_privileged_access(message: &impl SVMMessage) -> bool {
-    for instruction in message.instructions_iter() {
+    let instructions = message.instructions_iter().collect::<Vec<_>>();
+    if instructions.len() == 2
+        && instruction_program_id(message, &instructions[0]) == Some(MAGIC_PROGRAM_ID)
+        && instruction_program_id(message, &instructions[1])
+            == Some(POST_DELEGATION_ACTION_EXECUTOR_PROGRAM_ID)
+    {
+        return instruction_discriminant(&instructions[0]).is_some_and(|d| {
+            d == CLONE_ACCOUNT_DISCRIMINANT || d == CLONE_ACCOUNT_CONTINUE_DISCRIMINANT
+        });
+    }
+
+    for instruction in instructions {
         let Some(program) = message
             .account_keys()
             .get(instruction.program_id_index as usize)
@@ -88,17 +103,30 @@ fn has_privileged_access(message: &impl SVMMessage) -> bool {
             return false;
         }
 
-        let discriminant = instruction
-            .data
-            .get(0..4)
-            .and_then(|bytes| <[u8; 4]>::try_from(bytes).ok())
-            .map(u32::from_le_bytes)
-            .unwrap_or(u32::MAX);
+        let discriminant = instruction_discriminant(&instruction).unwrap_or(u32::MAX);
         if !PRIVILEGED_MAGIC_DISCRIMINANTS.contains(&discriminant) {
             return false;
         }
     }
     true
+}
+
+fn instruction_program_id(
+    message: &impl SVMMessage,
+    instruction: &SVMInstruction<'_>,
+) -> Option<Pubkey> {
+    message
+        .account_keys()
+        .get(instruction.program_id_index as usize)
+        .copied()
+}
+
+fn instruction_discriminant(instruction: &SVMInstruction<'_>) -> Option<u32> {
+    instruction
+        .data
+        .get(0..4)
+        .and_then(|bytes| <[u8; 4]>::try_from(bytes).ok())
+        .map(u32::from_le_bytes)
 }
 
 #[cfg(test)]
@@ -171,6 +199,33 @@ mod tests {
         ))
     }
 
+    fn message_with_programs(instructions: Vec<(Pubkey, Vec<u8>)>) -> SanitizedMessage {
+        let mut account_keys = vec![Pubkey::new_unique(), Pubkey::new_unique()];
+        account_keys.extend(instructions.iter().map(|(program, _)| *program));
+
+        SanitizedMessage::Legacy(LegacyMessage::new(
+            Message {
+                account_keys,
+                header: MessageHeader {
+                    num_required_signatures: 1,
+                    num_readonly_signed_accounts: 0,
+                    num_readonly_unsigned_accounts: instructions.len() as u8,
+                },
+                instructions: instructions
+                    .into_iter()
+                    .enumerate()
+                    .map(|(idx, (_, data))| CompiledInstruction {
+                        program_id_index: (idx + 2) as u8,
+                        accounts: vec![1],
+                        data,
+                    })
+                    .collect(),
+                recent_blockhash: Hash::default(),
+            },
+            &HashSet::new(),
+        ))
+    }
+
     #[test]
     fn privileged_payer_allows_magic_control_instruction() {
         let payer = Pubkey::new_unique();
@@ -181,6 +236,85 @@ mod tests {
         tx.validate_accounts_access(&message);
 
         assert_eq!(tx.execution_details.status, Ok(()));
+    }
+
+    #[test]
+    fn privileged_payer_allows_clone_with_post_delegation_action_executor() {
+        let payer = Pubkey::new_unique();
+        let writable = Pubkey::new_unique();
+        let mut tx = executed_transaction(payer, writable);
+        let message = message_with_programs(vec![
+            (
+                MAGIC_PROGRAM_ID,
+                CLONE_ACCOUNT_DISCRIMINANT.to_le_bytes().to_vec(),
+            ),
+            (POST_DELEGATION_ACTION_EXECUTOR_PROGRAM_ID, vec![]),
+        ]);
+
+        tx.validate_accounts_access(&message);
+
+        assert_eq!(tx.execution_details.status, Ok(()));
+    }
+
+    #[test]
+    fn privileged_payer_allows_clone_continue_with_post_delegation_action_executor() {
+        let payer = Pubkey::new_unique();
+        let writable = Pubkey::new_unique();
+        let mut tx = executed_transaction(payer, writable);
+        let message = message_with_programs(vec![
+            (
+                MAGIC_PROGRAM_ID,
+                CLONE_ACCOUNT_CONTINUE_DISCRIMINANT.to_le_bytes().to_vec(),
+            ),
+            (POST_DELEGATION_ACTION_EXECUTOR_PROGRAM_ID, vec![]),
+        ]);
+
+        tx.validate_accounts_access(&message);
+
+        assert_eq!(tx.execution_details.status, Ok(()));
+    }
+
+    #[test]
+    fn privileged_payer_rejects_post_delegation_action_executor_without_clone() {
+        let payer = Pubkey::new_unique();
+        let writable = Pubkey::new_unique();
+        let mut tx = executed_transaction(payer, writable);
+        let message = message_with_programs(vec![
+            (MAGIC_PROGRAM_ID, 1u32.to_le_bytes().to_vec()),
+            (POST_DELEGATION_ACTION_EXECUTOR_PROGRAM_ID, vec![]),
+        ]);
+
+        tx.validate_accounts_access(&message);
+
+        assert_eq!(
+            tx.execution_details.status,
+            Err(TransactionError::InvalidWritableAccount)
+        );
+    }
+
+    #[test]
+    fn privileged_payer_rejects_post_delegation_action_executor_with_extra_ix() {
+        let payer = Pubkey::new_unique();
+        let writable = Pubkey::new_unique();
+        let mut tx = executed_transaction(payer, writable);
+        let message = message_with_programs(vec![
+            (
+                MAGIC_PROGRAM_ID,
+                CLONE_ACCOUNT_DISCRIMINANT.to_le_bytes().to_vec(),
+            ),
+            (POST_DELEGATION_ACTION_EXECUTOR_PROGRAM_ID, vec![]),
+            (
+                MAGIC_PROGRAM_ID,
+                CLONE_ACCOUNT_DISCRIMINANT.to_le_bytes().to_vec(),
+            ),
+        ]);
+
+        tx.validate_accounts_access(&message);
+
+        assert_eq!(
+            tx.execution_details.status,
+            Err(TransactionError::InvalidWritableAccount)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a privileged-access mode in [solana-svm](https://github.com/magicblock-labs/magicblock-svm/tree/fix/post-action-executor-privileged-access/svm) for transactions shaped as Magic clone or clone-continue followed by PostAct.
- Keep Magic-only control transactions fully privileged, but for clone -> PostAct only bypass the fee payer and the cloned account at instruction account index 1.
- Reject malformed executor transactions that add extra non-delegated writable accounts, even when those accounts are also present as clone remaining accounts.
