### PR TITLE
Support newer sBPF v3 ELF layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,9 +17,8 @@ dependencies = [
 [[package]]
 name = "agave-syscalls"
 version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5212f0b24fc37d4c844ae25b563d0cf5587d092912820c40f88d4b9b301148f8"
 dependencies = [
+ "assert_matches",
  "bincode",
  "libsecp256k1",
  "num-traits",
@@ -31,18 +30,25 @@ dependencies = [
  "solana-clock",
  "solana-cpi",
  "solana-curve25519",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-fee-calculator",
  "solana-hash 3.1.0",
  "solana-instruction",
  "solana-keccak-hasher",
+ "solana-last-restart-slot",
  "solana-loader-v3-interface",
  "solana-poseidon",
+ "solana-program",
  "solana-program-entrypoint",
  "solana-program-runtime",
  "solana-pubkey 3.0.0",
+ "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-secp256k1-recover",
  "solana-sha256-hasher",
+ "solana-slot-hashes",
  "solana-stable-layout",
  "solana-stake-interface",
  "solana-svm-callback",
@@ -54,6 +60,8 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction-context",
+ "static_assertions",
+ "test-case",
  "thiserror 2.0.18",
 ]
 
@@ -1548,6 +1556,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2343,6 +2360,8 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
 dependencies = [
+ "bincode",
+ "serde_core",
  "solana-address 2.6.0",
  "solana-program-error",
  "solana-program-memory",
@@ -2379,6 +2398,18 @@ dependencies = [
  "solana-sanitize",
  "solana-sha256-hasher",
  "wincode",
+]
+
+[[package]]
+name = "solana-address-lookup-table-interface"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115b4f773acc4f3f3cb986b0d335e9845c0368c82b0940410935bc11ae065578"
+dependencies = [
+ "solana-clock",
+ "solana-pubkey 4.2.0",
+ "solana-sdk-ids",
+ "solana-slot-hashes",
 ]
 
 [[package]]
@@ -2439,32 +2470,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-borsh"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c04abbae16f57178a163125805637b8a076175bb5c0002fb04f4792bea901cf7"
+dependencies = [
+ "borsh",
+]
+
+[[package]]
 name = "solana-bpf-loader-program"
 version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "044a6c5327755992853454ea5ec495edd987dab53a6f9029e695bf0d43ab55dc"
 dependencies = [
  "agave-syscalls",
+ "assert_matches",
  "bincode",
  "qualifier_attr",
+ "rand 0.8.6",
  "solana-account",
  "solana-bincode",
+ "solana-bpf-loader-program",
  "solana-clock",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-fee-calculator",
  "solana-instruction",
+ "solana-last-restart-slot",
  "solana-loader-v3-interface",
  "solana-loader-v4-interface",
  "solana-packet",
+ "solana-program",
  "solana-program-entrypoint",
  "solana-program-runtime",
  "solana-pubkey 3.0.0",
+ "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
+ "solana-slot-hashes",
+ "solana-svm-callback",
  "solana-svm-feature-set",
  "solana-svm-log-collector",
  "solana-svm-measure",
  "solana-svm-type-overrides",
  "solana-system-interface 2.0.0",
  "solana-transaction-context",
+ "static_assertions",
+ "test-case",
 ]
 
 [[package]]
@@ -2595,6 +2646,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-epoch-stake"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027e6d0b9e7daac5b2ac7c3f9ca1b727861121d9ef05084cf435ff736051e7c2"
+dependencies = [
+ "solana-define-syscall 5.1.0",
+ "solana-pubkey 4.2.0",
+]
+
+[[package]]
+name = "solana-example-mocks"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978855d164845c1b0235d4b4d101cadc55373fffaf0b5b6cfa2194d25b2ed658"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-address-lookup-table-interface",
+ "solana-clock",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-keccak-hasher",
+ "solana-message",
+ "solana-nonce",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "solana-system-interface 2.0.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "solana-fee-calculator"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2682,6 +2764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ebb0ffd19263051bc3f683fcc086134b8ff23af894dcb63f7563c7137b42f1"
 dependencies = [
  "bincode",
+ "borsh",
  "serde",
  "serde_derive",
  "solana-define-syscall 5.1.0",
@@ -2792,13 +2875,13 @@ dependencies = [
 [[package]]
 name = "solana-loader-v4-program"
 version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e88b98ba6b408fe6fcf180784fc378d07ae63100c7dd413ff97474b6de30c5d"
 dependencies = [
+ "bincode",
  "log",
  "solana-account",
  "solana-bincode",
  "solana-bpf-loader-program",
+ "solana-clock",
  "solana-instruction",
  "solana-loader-v3-interface",
  "solana-loader-v4-interface",
@@ -2810,6 +2893,7 @@ dependencies = [
  "solana-svm-log-collector",
  "solana-svm-measure",
  "solana-svm-type-overrides",
+ "solana-sysvar",
  "solana-transaction-context",
 ]
 
@@ -2907,6 +2991,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-program"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91b12305dd81045d705f427acd0435a2e46444b65367d7179d7bdcfc3bc5f5eb"
+dependencies = [
+ "memoffset",
+ "solana-account-info",
+ "solana-big-mod-exp",
+ "solana-blake3-hasher",
+ "solana-borsh",
+ "solana-clock",
+ "solana-cpi",
+ "solana-define-syscall 3.0.0",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-epoch-stake",
+ "solana-example-mocks",
+ "solana-fee-calculator",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-instructions-sysvar",
+ "solana-keccak-hasher",
+ "solana-last-restart-slot",
+ "solana-msg",
+ "solana-native-token",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-secp256k1-recover",
+ "solana-serde-varint",
+ "solana-serialize-utils",
+ "solana-sha256-hasher",
+ "solana-short-vec",
+ "solana-slot-hashes",
+ "solana-slot-history",
+ "solana-stable-layout",
+ "solana-sysvar",
+ "solana-sysvar-id",
+]
+
+[[package]]
 name = "solana-program-binaries"
 version = "3.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2939,6 +3070,11 @@ name = "solana-program-error"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f04fa578707b3612b095f0c8e19b66a1233f7c42ca8082fcb3b745afcc0add6"
+dependencies = [
+ "borsh",
+ "serde",
+ "serde_derive",
+]
 
 [[package]]
 name = "solana-program-memory"
@@ -3056,9 +3192,9 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.13.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15b079e08471a9dbfe1e48b2c7439c85aa2a055cbd54eddd8bd257b0a7dbb29"
+checksum = "733b3657a0fab205102b799dbe17f85d3972cf984232c1b0b108fa6ba438e382"
 dependencies = [
  "byteorder",
  "combine",
@@ -3142,6 +3278,15 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "solana-serde-varint"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950e5b83e839dc0f92c66afc124bb8f40e89bc90f0579e8ec5499296d27f54e3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3480,6 +3625,8 @@ checksum = "6690d3dd88f15c21edff68eb391ef8800df7a1f5cec84ee3e8d1abf05affdf74"
 dependencies = [
  "base64 0.22.1",
  "bincode",
+ "bytemuck",
+ "bytemuck_derive",
  "lazy_static",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,13 @@
 [workspace]
-members = ["program-runtime", "solana-account", "svm", "transaction-context"]
+members = [
+  "bpf-loader-program",
+  "loader-v4-program",
+  "program-runtime",
+  "solana-account",
+  "svm",
+  "syscalls",
+  "transaction-context",
+]
 resolver = "2"
 
 [workspace.package]
@@ -12,7 +20,7 @@ edition = "2021"
 
 [workspace.dependencies]
 agave-logger = { version = "3.1", features = ["agave-unstable-api"] }
-agave-syscalls = "3.1"
+agave-syscalls = { path = "syscalls", version = "=3.1.12" }
 ahash = "0.8.11"
 assert_matches = "1.5.0"
 base64 = "0.22.1"
@@ -24,6 +32,7 @@ libsecp256k1 = { version = "0.6.0", default-features = false, features = [
   "static-context",
 ] }
 log = "0.4.28"
+num-traits = "0.2"
 openssl = "0.10"
 percentage = "0.1.0"
 qualifier_attr = "0.2.2"
@@ -39,7 +48,11 @@ test-case = "3.3"
 thiserror = "2.0"
 solana-account = { path = "solana-account", version = "3.4.0" }
 solana-account-info = "3.1.1"
-solana-bpf-loader-program = "3.1"
+solana-big-mod-exp = "3.0"
+solana-bincode = "3.1"
+solana-blake3-hasher = { version = "3.1", features = ["blake3"] }
+solana-bn254 = "3.2"
+solana-bpf-loader-program = { path = "bpf-loader-program", version = "=3.1.12" }
 solana-clock = "3.0.0"
 solana-compute-budget = { version = "3.1", features = ["agave-unstable-api"] }
 solana-compute-budget-interface = "3.0"
@@ -58,10 +71,13 @@ solana-instruction = "3.0"
 solana-instruction-error = "2.2"
 solana-instructions-sysvar = "3.0"
 solana-keypair = "3.0"
+solana-cpi = "3.1"
+solana-curve25519 = { version = "3.1", features = ["agave-unstable-api"] }
+solana-keccak-hasher = { version = "3.1", features = ["sha3"] }
 solana-last-restart-slot = "3.0.0"
 solana-loader-v3-interface = "6.1.0"
 solana-loader-v4-interface = "3.1"
-solana-loader-v4-program = { version = "3.1", features = [
+solana-loader-v4-program = { path = "loader-v4-program", version = "=3.1.12", features = [
   "agave-unstable-api",
 ] }
 solana-message = "3.0"
@@ -73,12 +89,17 @@ solana-program-binaries = { version = "3.1", features = ["agave-unstable-api"] }
 solana-program-entrypoint = "3.1"
 solana-program-pack = "3.1"
 solana-program-runtime = { path = "program-runtime" }
+solana-program = "3.0"
+solana-poseidon = { version = "3.1", features = ["agave-unstable-api"] }
 solana-pubkey = "3.0"
+solana-packet = "3.0"
 solana-rent = "3.0"
-solana-sbpf = "0.13.1"
+solana-sbpf = "0.14.4"
 solana-sdk-ids = "3.0"
 solana-secp256k1-program = { version = "3.0", features = ["bincode"] }
 solana-secp256r1-program = { version = "3.0", features = ["openssl-vendored"] }
+solana-secp256k1-recover = "3.1"
+solana-sha256-hasher = "3.1"
 solana-signature = "3.1.0"
 solana-signer = "3.0"
 solana-slot-hashes = "3.0.1"
@@ -109,6 +130,9 @@ check-cfg = [
 ]
 
 [patch.crates-io]
+agave-syscalls = { path = "syscalls" }
 solana-account = { path = "solana-account" }
+solana-bpf-loader-program = { path = "bpf-loader-program" }
+solana-loader-v4-program = { path = "loader-v4-program" }
 solana-program-runtime = { path = "program-runtime" }
 solana-transaction-context = { path = "transaction-context" }

--- a/bpf-loader-program/Cargo.toml
+++ b/bpf-loader-program/Cargo.toml
@@ -1,0 +1,69 @@
+[package]
+name = "solana-bpf-loader-program"
+description = "Solana BPF loader"
+documentation = "https://docs.rs/solana-bpf-loader-program"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_bpf_loader_program"
+
+[features]
+default = ["metrics"]
+agave-unstable-api = []
+metrics = ["solana-program-runtime/metrics"]
+shuttle-test = [
+    "solana-program-runtime/shuttle-test",
+    "solana-sbpf/shuttle-test",
+    "solana-svm-type-overrides/shuttle-test",
+]
+svm-internal = []
+
+[dependencies]
+agave-syscalls = { workspace = true }
+bincode = { workspace = true }
+qualifier_attr = { workspace = true }
+solana-account = { workspace = true }
+solana-bincode = { workspace = true }
+solana-clock = { workspace = true }
+solana-instruction = { workspace = true }
+solana-loader-v3-interface = { workspace = true, features = ["serde"] }
+solana-loader-v4-interface = { workspace = true, features = ["bincode"] }
+solana-packet = { workspace = true }
+solana-program-entrypoint = { workspace = true }
+solana-program-runtime = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-sbpf = { workspace = true, features = ["jit"] }
+solana-sdk-ids = { workspace = true }
+solana-svm-feature-set = { workspace = true }
+solana-svm-log-collector = { workspace = true }
+solana-svm-measure = { workspace = true }
+solana-svm-type-overrides = { workspace = true }
+solana-system-interface = { workspace = true }
+solana-transaction-context = { workspace = true, features = ["bincode"] }
+
+[dev-dependencies]
+assert_matches = { workspace = true }
+rand = { workspace = true }
+solana-bpf-loader-program = { path = ".", features = ["agave-unstable-api", "svm-internal"] }
+solana-epoch-rewards = { workspace = true }
+solana-epoch-schedule = { workspace = true }
+solana-fee-calculator = { workspace = true }
+solana-last-restart-slot = { workspace = true }
+solana-program = { workspace = true }
+solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-pubkey = { workspace = true, features = ["rand"] }
+solana-rent = { workspace = true }
+solana-slot-hashes = { workspace = true }
+solana-svm-callback = { workspace = true }
+solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
+static_assertions = { workspace = true }
+test-case = { workspace = true }

--- a/bpf-loader-program/src/lib.rs
+++ b/bpf-loader-program/src/lib.rs
@@ -1,0 +1,4053 @@
+#![cfg_attr(
+    not(feature = "agave-unstable-api"),
+    deprecated(
+        since = "3.1.0",
+        note = "This crate has been marked for formal inclusion in the Agave Unstable API. From \
+                v4.0.0 onward, the `agave-unstable-api` crate feature must be specified to \
+                acknowledge use of an interface that may break without warning."
+    )
+)]
+#![deny(clippy::arithmetic_side_effects)]
+#![deny(clippy::indexing_slicing)]
+
+#[cfg(feature = "svm-internal")]
+use qualifier_attr::qualifiers;
+use {
+    solana_bincode::limited_deserialize,
+    solana_clock::Slot,
+    solana_instruction::{error::InstructionError, AccountMeta},
+    solana_loader_v3_interface::{
+        instruction::UpgradeableLoaderInstruction, state::UpgradeableLoaderState,
+    },
+    solana_program_entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
+    solana_program_runtime::{
+        execution_budget::MAX_INSTRUCTION_STACK_DEPTH,
+        invoke_context::{BpfAllocator, InvokeContext, SerializedAccountMetadata, SyscallContext},
+        loaded_programs::{
+            LoadProgramMetrics, ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
+            ProgramCacheForTxBatch, ProgramRuntimeEnvironment, DELAY_VISIBILITY_SLOT_OFFSET,
+        },
+        mem_pool::VmMemoryPool,
+        serialization, stable_log,
+        sysvar_cache::get_sysvar_with_account_check,
+    },
+    solana_pubkey::Pubkey,
+    solana_sbpf::{
+        declare_builtin_function,
+        ebpf::{self, MM_HEAP_START},
+        elf::{ElfError, Executable},
+        error::{EbpfError, ProgramResult},
+        memory_region::{AccessType, MemoryMapping, MemoryRegion},
+        program::BuiltinProgram,
+        verifier::RequisiteVerifier,
+        vm::{ContextObject, EbpfVm},
+    },
+    solana_sdk_ids::{
+        bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4, native_loader,
+    },
+    solana_svm_log_collector::{ic_logger_msg, ic_msg, LogCollector},
+    solana_svm_measure::measure::Measure,
+    solana_svm_type_overrides::sync::{atomic::Ordering, Arc},
+    solana_system_interface::{instruction as system_instruction, MAX_PERMITTED_DATA_LENGTH},
+    solana_transaction_context::{IndexOfAccount, InstructionContext, TransactionContext},
+    std::{cell::RefCell, mem, rc::Rc},
+};
+
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+const DEFAULT_LOADER_COMPUTE_UNITS: u64 = 570;
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+const DEPRECATED_LOADER_COMPUTE_UNITS: u64 = 1_140;
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+const UPGRADEABLE_LOADER_COMPUTE_UNITS: u64 = 2_370;
+
+thread_local! {
+    pub static MEMORY_POOL: RefCell<VmMemoryPool> = RefCell::new(VmMemoryPool::new());
+}
+
+fn morph_into_deployment_environment_v1<'a>(
+    from: Arc<BuiltinProgram<InvokeContext<'a, 'a>>>,
+) -> Result<BuiltinProgram<InvokeContext<'a, 'a>>, ElfError> {
+    let mut config = from.get_config().clone();
+    config.reject_broken_elfs = true;
+    // Once the tests are being build using a toolchain which supports the newer SBPF versions,
+    // the deployment of older versions will be disabled:
+    // config.enabled_sbpf_versions =
+    //     *config.enabled_sbpf_versions.end()..=*config.enabled_sbpf_versions.end();
+
+    let mut result = BuiltinProgram::new_loader(config);
+
+    for (_key, (name, value)) in from.get_function_registry().iter() {
+        // Deployment of programs with sol_alloc_free is disabled. So do not register the syscall.
+        if name != *b"sol_alloc_free_" {
+            result.register_function(unsafe { std::str::from_utf8_unchecked(name) }, value)?;
+        }
+    }
+
+    Ok(result)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn load_program_from_bytes(
+    log_collector: Option<Rc<RefCell<LogCollector>>>,
+    load_program_metrics: &mut LoadProgramMetrics,
+    programdata: &[u8],
+    loader_key: &Pubkey,
+    account_size: usize,
+    deployment_slot: Slot,
+    program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static, 'static>>>,
+    reloading: bool,
+) -> Result<ProgramCacheEntry, InstructionError> {
+    let effective_slot = deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET);
+    let loaded_program = if reloading {
+        // Safety: this is safe because the program is being reloaded in the cache.
+        unsafe {
+            ProgramCacheEntry::reload(
+                loader_key,
+                program_runtime_environment,
+                deployment_slot,
+                effective_slot,
+                programdata,
+                account_size,
+                load_program_metrics,
+            )
+        }
+    } else {
+        ProgramCacheEntry::new(
+            loader_key,
+            program_runtime_environment,
+            deployment_slot,
+            effective_slot,
+            programdata,
+            account_size,
+            load_program_metrics,
+        )
+    }
+    .map_err(|err| {
+        ic_logger_msg!(log_collector, "{}", err);
+        InstructionError::InvalidAccountData
+    })?;
+    Ok(loaded_program)
+}
+
+/// Directly deploy a program using a provided invoke context.
+/// This function should only be invoked from the runtime, since it does not
+/// provide any account loads or checks.
+pub fn deploy_program(
+    log_collector: Option<Rc<RefCell<LogCollector>>>,
+    program_cache_for_tx_batch: &mut ProgramCacheForTxBatch,
+    program_runtime_environment: ProgramRuntimeEnvironment,
+    program_id: &Pubkey,
+    loader_key: &Pubkey,
+    account_size: usize,
+    programdata: &[u8],
+    deployment_slot: Slot,
+) -> Result<LoadProgramMetrics, InstructionError> {
+    let mut load_program_metrics = LoadProgramMetrics::default();
+    let mut register_syscalls_time = Measure::start("register_syscalls_time");
+    let deployment_program_runtime_environment =
+        morph_into_deployment_environment_v1(program_runtime_environment.clone()).map_err(|e| {
+            ic_logger_msg!(log_collector, "Failed to register syscalls: {}", e);
+            InstructionError::ProgramEnvironmentSetupFailure
+        })?;
+    register_syscalls_time.stop();
+    load_program_metrics.register_syscalls_us = register_syscalls_time.as_us();
+    // Verify using stricter deployment_program_runtime_environment
+    let mut load_elf_time = Measure::start("load_elf_time");
+    let executable = Executable::<InvokeContext>::load(
+        programdata,
+        Arc::new(deployment_program_runtime_environment),
+    )
+    .map_err(|err| {
+        ic_logger_msg!(log_collector, "{}", err);
+        InstructionError::InvalidAccountData
+    })?;
+    load_elf_time.stop();
+    load_program_metrics.load_elf_us = load_elf_time.as_us();
+    let mut verify_code_time = Measure::start("verify_code_time");
+    executable.verify::<RequisiteVerifier>().map_err(|err| {
+        ic_logger_msg!(log_collector, "{}", err);
+        InstructionError::InvalidAccountData
+    })?;
+    verify_code_time.stop();
+    load_program_metrics.verify_code_us = verify_code_time.as_us();
+    // Reload but with program_runtime_environment
+    let executor = load_program_from_bytes(
+        log_collector,
+        &mut load_program_metrics,
+        programdata,
+        loader_key,
+        account_size,
+        deployment_slot,
+        program_runtime_environment,
+        true,
+    )?;
+    if let Some(old_entry) = program_cache_for_tx_batch.find(program_id) {
+        executor.tx_usage_counter.store(
+            old_entry.tx_usage_counter.load(Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
+    }
+    load_program_metrics.program_id = program_id.to_string();
+    program_cache_for_tx_batch.store_modified_entry(*program_id, Arc::new(executor));
+    Ok(load_program_metrics)
+}
+
+#[macro_export]
+macro_rules! deploy_program {
+    ($invoke_context:expr, $program_id:expr, $loader_key:expr, $account_size:expr, $programdata:expr, $deployment_slot:expr $(,)?) => {
+        assert_eq!(
+            $deployment_slot,
+            $invoke_context.program_cache_for_tx_batch.slot()
+        );
+        let load_program_metrics = $crate::deploy_program(
+            $invoke_context.get_log_collector(),
+            $invoke_context.program_cache_for_tx_batch,
+            $invoke_context
+                .get_program_runtime_environments_for_deployment()
+                .program_runtime_v1
+                .clone(),
+            $program_id,
+            $loader_key,
+            $account_size,
+            $programdata,
+            $deployment_slot,
+        )?;
+        load_program_metrics.submit_datapoint(&mut $invoke_context.timings);
+    };
+}
+
+fn write_program_data(
+    program_data_offset: usize,
+    bytes: &[u8],
+    invoke_context: &mut InvokeContext,
+) -> Result<(), InstructionError> {
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let mut program = instruction_context.try_borrow_instruction_account(0)?;
+    let data = program.get_data_mut()?;
+    let write_offset = program_data_offset.saturating_add(bytes.len());
+    if data.len() < write_offset {
+        ic_msg!(
+            invoke_context,
+            "Write overflow: {} < {}",
+            data.len(),
+            write_offset,
+        );
+        return Err(InstructionError::AccountDataTooSmall);
+    }
+    data.get_mut(program_data_offset..write_offset)
+        .ok_or(InstructionError::AccountDataTooSmall)?
+        .copy_from_slice(bytes);
+    Ok(())
+}
+
+/// Only used in macro, do not use directly!
+pub fn calculate_heap_cost(heap_size: u32, heap_cost: u64) -> u64 {
+    const KIBIBYTE: u64 = 1024;
+    const PAGE_SIZE_KB: u64 = 32;
+    let mut rounded_heap_size = u64::from(heap_size);
+    rounded_heap_size =
+        rounded_heap_size.saturating_add(PAGE_SIZE_KB.saturating_mul(KIBIBYTE).saturating_sub(1));
+    rounded_heap_size
+        .checked_div(PAGE_SIZE_KB.saturating_mul(KIBIBYTE))
+        .expect("PAGE_SIZE_KB * KIBIBYTE > 0")
+        .saturating_sub(1)
+        .saturating_mul(heap_cost)
+}
+
+/// Only used in macro, do not use directly!
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+fn create_vm<'a, 'b>(
+    program: &'a Executable<InvokeContext<'b, 'b>>,
+    regions: Vec<MemoryRegion>,
+    accounts_metadata: Vec<SerializedAccountMetadata>,
+    invoke_context: &'a mut InvokeContext<'b, 'b>,
+    stack: &mut [u8],
+    heap: &mut [u8],
+) -> Result<EbpfVm<'a, InvokeContext<'b, 'b>>, Box<dyn std::error::Error>> {
+    let stack_size = stack.len();
+    let heap_size = heap.len();
+    let memory_mapping = create_memory_mapping(
+        program,
+        stack,
+        heap,
+        regions,
+        invoke_context.transaction_context,
+        invoke_context
+            .get_feature_set()
+            .stricter_abi_and_runtime_constraints,
+        invoke_context.get_feature_set().account_data_direct_mapping,
+    )?;
+    invoke_context.set_syscall_context(SyscallContext {
+        allocator: BpfAllocator::new(heap_size as u64),
+        accounts_metadata,
+    })?;
+    Ok(EbpfVm::new(
+        program.get_loader().clone(),
+        program.get_sbpf_version(),
+        invoke_context,
+        memory_mapping,
+        stack_size,
+    ))
+}
+
+/// Create the SBF virtual machine
+#[macro_export]
+macro_rules! create_vm {
+    ($vm:ident, $program:expr, $regions:expr, $accounts_metadata:expr, $invoke_context:expr $(,)?) => {
+        let invoke_context = &*$invoke_context;
+        let stack_size = $program.get_config().stack_size();
+        let heap_size = invoke_context.get_compute_budget().heap_size;
+        let heap_cost_result = invoke_context.consume_checked($crate::calculate_heap_cost(
+            heap_size,
+            invoke_context.get_execution_cost().heap_cost,
+        ));
+        let $vm = heap_cost_result.and_then(|_| {
+            let (mut stack, mut heap) = $crate::MEMORY_POOL
+                .with_borrow_mut(|pool| (pool.get_stack(stack_size), pool.get_heap(heap_size)));
+            let vm = $crate::create_vm(
+                $program,
+                $regions,
+                $accounts_metadata,
+                $invoke_context,
+                stack
+                    .as_slice_mut()
+                    .get_mut(..stack_size)
+                    .expect("invalid stack size"),
+                heap.as_slice_mut()
+                    .get_mut(..heap_size as usize)
+                    .expect("invalid heap size"),
+            );
+            vm.map(|vm| (vm, stack, heap))
+        });
+    };
+}
+
+fn create_memory_mapping<'a, 'b, C: ContextObject>(
+    executable: &'a Executable<C>,
+    stack: &'b mut [u8],
+    heap: &'b mut [u8],
+    additional_regions: Vec<MemoryRegion>,
+    transaction_context: &TransactionContext,
+    stricter_abi_and_runtime_constraints: bool,
+    account_data_direct_mapping: bool,
+) -> Result<MemoryMapping, Box<dyn std::error::Error>> {
+    let config = executable.get_config();
+    let sbpf_version = executable.get_sbpf_version();
+    let regions: Vec<MemoryRegion> = vec![
+        executable.get_ro_region(),
+        MemoryRegion::new_writable_gapped(
+            stack,
+            ebpf::MM_STACK_START,
+            if sbpf_version.stack_frame_gaps() && config.enable_stack_frame_gaps {
+                config.stack_frame_size as u64
+            } else {
+                0
+            },
+        ),
+        MemoryRegion::new_writable(heap, MM_HEAP_START),
+    ]
+    .into_iter()
+    .chain(additional_regions)
+    .collect();
+
+    Ok(MemoryMapping::new_with_access_violation_handler(
+        regions,
+        config,
+        sbpf_version,
+        transaction_context.access_violation_handler(
+            stricter_abi_and_runtime_constraints,
+            account_data_direct_mapping,
+        ),
+    )?)
+}
+
+declare_builtin_function!(
+    Entrypoint,
+    fn rust(
+        invoke_context: &mut InvokeContext<'static, 'static>,
+        _arg0: u64,
+        _arg1: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Box<dyn std::error::Error>> {
+        process_instruction_inner(invoke_context)
+    }
+);
+
+mod migration_authority {
+    solana_pubkey::declare_id!("3Scf35jMNk2xXBD6areNjgMtXgp5ZspDhms8vdcbzC42");
+}
+
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+pub(crate) fn process_instruction_inner<'a>(
+    invoke_context: &mut InvokeContext<'a, 'a>,
+) -> Result<u64, Box<dyn std::error::Error>> {
+    let log_collector = invoke_context.get_log_collector();
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let program_id = instruction_context.get_program_key()?;
+    let owner_id = instruction_context.get_program_owner()?;
+
+    // Program Management Instruction
+    if native_loader::check_id(&owner_id) {
+        let program_id = instruction_context.get_program_key()?;
+        return if bpf_loader_upgradeable::check_id(program_id) {
+            invoke_context.consume_checked(UPGRADEABLE_LOADER_COMPUTE_UNITS)?;
+            process_loader_upgradeable_instruction(invoke_context)
+        } else if bpf_loader::check_id(program_id) {
+            invoke_context.consume_checked(DEFAULT_LOADER_COMPUTE_UNITS)?;
+            ic_logger_msg!(
+                log_collector,
+                "BPF loader management instructions are no longer supported",
+            );
+            Err(InstructionError::UnsupportedProgramId)
+        } else if bpf_loader_deprecated::check_id(program_id) {
+            invoke_context.consume_checked(DEPRECATED_LOADER_COMPUTE_UNITS)?;
+            ic_logger_msg!(log_collector, "Deprecated loader is no longer supported");
+            Err(InstructionError::UnsupportedProgramId)
+        } else {
+            ic_logger_msg!(log_collector, "Invalid BPF loader id");
+            Err(InstructionError::UnsupportedProgramId)
+        }
+        .map(|_| 0)
+        .map_err(|error| Box::new(error) as Box<dyn std::error::Error>);
+    }
+
+    // Program Invocation
+    let mut get_or_create_executor_time = Measure::start("get_or_create_executor_time");
+    let executor = invoke_context
+        .program_cache_for_tx_batch
+        .find(program_id)
+        .ok_or_else(|| {
+            ic_logger_msg!(log_collector, "Program is not cached");
+            InstructionError::UnsupportedProgramId
+        })?;
+    get_or_create_executor_time.stop();
+    invoke_context.timings.get_or_create_executor_us += get_or_create_executor_time.as_us();
+
+    match &executor.program {
+        ProgramCacheEntryType::FailedVerification(_)
+        | ProgramCacheEntryType::Closed
+        | ProgramCacheEntryType::DelayVisibility => {
+            ic_logger_msg!(log_collector, "Program is not deployed");
+            Err(Box::new(InstructionError::UnsupportedProgramId) as Box<dyn std::error::Error>)
+        }
+        ProgramCacheEntryType::Loaded(executable) => execute(executable, invoke_context),
+        _ => Err(Box::new(InstructionError::UnsupportedProgramId) as Box<dyn std::error::Error>),
+    }
+    .map(|_| 0)
+}
+
+fn process_loader_upgradeable_instruction(
+    invoke_context: &mut InvokeContext,
+) -> Result<(), InstructionError> {
+    let log_collector = invoke_context.get_log_collector();
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let instruction_data = instruction_context.get_instruction_data();
+    let program_id = instruction_context.get_program_key()?;
+
+    match limited_deserialize(instruction_data, solana_packet::PACKET_DATA_SIZE as u64)? {
+        UpgradeableLoaderInstruction::InitializeBuffer => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
+            let mut buffer = instruction_context.try_borrow_instruction_account(0)?;
+
+            if UpgradeableLoaderState::Uninitialized != buffer.get_state()? {
+                ic_logger_msg!(log_collector, "Buffer account already initialized");
+                return Err(InstructionError::AccountAlreadyInitialized);
+            }
+
+            let authority_key = Some(*instruction_context.get_key_of_instruction_account(1)?);
+
+            buffer.set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: authority_key,
+            })?;
+        }
+        UpgradeableLoaderInstruction::Write { offset, bytes } => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
+            let buffer = instruction_context.try_borrow_instruction_account(0)?;
+
+            if let UpgradeableLoaderState::Buffer { authority_address } = buffer.get_state()? {
+                if authority_address.is_none() {
+                    ic_logger_msg!(log_collector, "Buffer is immutable");
+                    return Err(InstructionError::Immutable); // TODO better error code
+                }
+                let authority_key = Some(*instruction_context.get_key_of_instruction_account(1)?);
+                if authority_address != authority_key {
+                    ic_logger_msg!(log_collector, "Incorrect buffer authority provided");
+                    return Err(InstructionError::IncorrectAuthority);
+                }
+                if !instruction_context.is_instruction_account_signer(1)? {
+                    ic_logger_msg!(log_collector, "Buffer authority did not sign");
+                    return Err(InstructionError::MissingRequiredSignature);
+                }
+            } else {
+                ic_logger_msg!(log_collector, "Invalid Buffer account");
+                return Err(InstructionError::InvalidAccountData);
+            }
+            drop(buffer);
+            write_program_data(
+                UpgradeableLoaderState::size_of_buffer_metadata().saturating_add(offset as usize),
+                &bytes,
+                invoke_context,
+            )?;
+        }
+        UpgradeableLoaderInstruction::DeployWithMaxDataLen { max_data_len } => {
+            instruction_context.check_number_of_instruction_accounts(4)?;
+            let payer_key = *instruction_context.get_key_of_instruction_account(0)?;
+            let programdata_key = *instruction_context.get_key_of_instruction_account(1)?;
+            let rent =
+                get_sysvar_with_account_check::rent(invoke_context, &instruction_context, 4)?;
+            let clock =
+                get_sysvar_with_account_check::clock(invoke_context, &instruction_context, 5)?;
+            instruction_context.check_number_of_instruction_accounts(8)?;
+            let authority_key = Some(*instruction_context.get_key_of_instruction_account(7)?);
+
+            // Verify Program account
+
+            let program = instruction_context.try_borrow_instruction_account(2)?;
+            if UpgradeableLoaderState::Uninitialized != program.get_state()? {
+                ic_logger_msg!(log_collector, "Program account already initialized");
+                return Err(InstructionError::AccountAlreadyInitialized);
+            }
+            if program.get_data().len() < UpgradeableLoaderState::size_of_program() {
+                ic_logger_msg!(log_collector, "Program account too small");
+                return Err(InstructionError::AccountDataTooSmall);
+            }
+            if program.get_lamports() < rent.minimum_balance(program.get_data().len()) {
+                ic_logger_msg!(log_collector, "Program account not rent-exempt");
+                return Err(InstructionError::ExecutableAccountNotRentExempt);
+            }
+            let new_program_id = *program.get_key();
+            drop(program);
+
+            // Verify Buffer account
+
+            let buffer = instruction_context.try_borrow_instruction_account(3)?;
+            if let UpgradeableLoaderState::Buffer { authority_address } = buffer.get_state()? {
+                if authority_address != authority_key {
+                    ic_logger_msg!(log_collector, "Buffer and upgrade authority don't match");
+                    return Err(InstructionError::IncorrectAuthority);
+                }
+                if !instruction_context.is_instruction_account_signer(7)? {
+                    ic_logger_msg!(log_collector, "Upgrade authority did not sign");
+                    return Err(InstructionError::MissingRequiredSignature);
+                }
+            } else {
+                ic_logger_msg!(log_collector, "Invalid Buffer account");
+                return Err(InstructionError::InvalidArgument);
+            }
+            let buffer_key = *buffer.get_key();
+            let buffer_data_offset = UpgradeableLoaderState::size_of_buffer_metadata();
+            let buffer_data_len = buffer.get_data().len().saturating_sub(buffer_data_offset);
+            let programdata_data_offset = UpgradeableLoaderState::size_of_programdata_metadata();
+            let programdata_len = UpgradeableLoaderState::size_of_programdata(max_data_len);
+            if buffer.get_data().len() < UpgradeableLoaderState::size_of_buffer_metadata()
+                || buffer_data_len == 0
+            {
+                ic_logger_msg!(log_collector, "Buffer account too small");
+                return Err(InstructionError::InvalidAccountData);
+            }
+            drop(buffer);
+            if max_data_len < buffer_data_len {
+                ic_logger_msg!(
+                    log_collector,
+                    "Max data length is too small to hold Buffer data"
+                );
+                return Err(InstructionError::AccountDataTooSmall);
+            }
+            if programdata_len > MAX_PERMITTED_DATA_LENGTH as usize {
+                ic_logger_msg!(log_collector, "Max data length is too large");
+                return Err(InstructionError::InvalidArgument);
+            }
+
+            // Create ProgramData account
+            let (derived_address, bump_seed) =
+                Pubkey::find_program_address(&[new_program_id.as_ref()], program_id);
+            if derived_address != programdata_key {
+                ic_logger_msg!(log_collector, "ProgramData address is not derived");
+                return Err(InstructionError::InvalidArgument);
+            }
+
+            // Drain the Buffer account to payer before paying for programdata account
+            {
+                let mut buffer = instruction_context.try_borrow_instruction_account(3)?;
+                let mut payer = instruction_context.try_borrow_instruction_account(0)?;
+                payer.checked_add_lamports(buffer.get_lamports())?;
+                buffer.set_lamports(0)?;
+            }
+
+            let owner_id = *program_id;
+            let mut instruction = system_instruction::create_account(
+                &payer_key,
+                &programdata_key,
+                1.max(rent.minimum_balance(programdata_len)),
+                programdata_len as u64,
+                program_id,
+            );
+
+            // pass an extra account to avoid the overly strict UnbalancedInstruction error
+            instruction
+                .accounts
+                .push(AccountMeta::new(buffer_key, false));
+
+            let transaction_context = &invoke_context.transaction_context;
+            let instruction_context = transaction_context.get_current_instruction_context()?;
+            let caller_program_id = instruction_context.get_program_key()?;
+            // The conversion from `PubkeyError` to `InstructionError` through
+            // num-traits is incorrect, but it's the existing behavior.
+            let signers = [[new_program_id.as_ref(), &[bump_seed]]]
+                .iter()
+                .map(|seeds| Pubkey::create_program_address(seeds, caller_program_id))
+                .collect::<Result<Vec<Pubkey>, solana_pubkey::PubkeyError>>()
+                .map_err(|e| e as u64)?;
+            invoke_context.native_invoke(instruction, signers.as_slice())?;
+
+            // Load and verify the program bits
+            let transaction_context = &invoke_context.transaction_context;
+            let instruction_context = transaction_context.get_current_instruction_context()?;
+            let buffer = instruction_context.try_borrow_instruction_account(3)?;
+            deploy_program!(
+                invoke_context,
+                &new_program_id,
+                &owner_id,
+                UpgradeableLoaderState::size_of_program().saturating_add(programdata_len),
+                buffer
+                    .get_data()
+                    .get(buffer_data_offset..)
+                    .ok_or(InstructionError::AccountDataTooSmall)?,
+                clock.slot,
+            );
+            drop(buffer);
+
+            let transaction_context = &invoke_context.transaction_context;
+            let instruction_context = transaction_context.get_current_instruction_context()?;
+
+            // Update the ProgramData account and record the program bits
+            {
+                let mut programdata = instruction_context.try_borrow_instruction_account(1)?;
+                programdata.set_state(&UpgradeableLoaderState::ProgramData {
+                    slot: clock.slot,
+                    upgrade_authority_address: authority_key,
+                })?;
+                let dst_slice = programdata
+                    .get_data_mut()?
+                    .get_mut(
+                        programdata_data_offset
+                            ..programdata_data_offset.saturating_add(buffer_data_len),
+                    )
+                    .ok_or(InstructionError::AccountDataTooSmall)?;
+                let mut buffer = instruction_context.try_borrow_instruction_account(3)?;
+                let src_slice = buffer
+                    .get_data()
+                    .get(buffer_data_offset..)
+                    .ok_or(InstructionError::AccountDataTooSmall)?;
+                dst_slice.copy_from_slice(src_slice);
+                buffer.set_data_length(UpgradeableLoaderState::size_of_buffer(0))?;
+            }
+
+            // Update the Program account
+            let mut program = instruction_context.try_borrow_instruction_account(2)?;
+            program.set_state(&UpgradeableLoaderState::Program {
+                programdata_address: programdata_key,
+            })?;
+            program.set_executable(true)?;
+            drop(program);
+
+            ic_logger_msg!(log_collector, "Deployed program {:?}", new_program_id);
+        }
+        UpgradeableLoaderInstruction::Upgrade => {
+            instruction_context.check_number_of_instruction_accounts(3)?;
+            let programdata_key = *instruction_context.get_key_of_instruction_account(0)?;
+            let rent =
+                get_sysvar_with_account_check::rent(invoke_context, &instruction_context, 4)?;
+            let clock =
+                get_sysvar_with_account_check::clock(invoke_context, &instruction_context, 5)?;
+            instruction_context.check_number_of_instruction_accounts(7)?;
+            let authority_key = Some(*instruction_context.get_key_of_instruction_account(6)?);
+
+            // Verify Program account
+
+            let program = instruction_context.try_borrow_instruction_account(1)?;
+            if !program.is_writable() {
+                ic_logger_msg!(log_collector, "Program account not writeable");
+                return Err(InstructionError::InvalidArgument);
+            }
+            if program.get_owner() != program_id {
+                ic_logger_msg!(log_collector, "Program account not owned by loader");
+                return Err(InstructionError::IncorrectProgramId);
+            }
+            if let UpgradeableLoaderState::Program {
+                programdata_address,
+            } = program.get_state()?
+            {
+                if programdata_address != programdata_key {
+                    ic_logger_msg!(log_collector, "Program and ProgramData account mismatch");
+                    return Err(InstructionError::InvalidArgument);
+                }
+            } else {
+                ic_logger_msg!(log_collector, "Invalid Program account");
+                return Err(InstructionError::InvalidAccountData);
+            }
+            let new_program_id = *program.get_key();
+            drop(program);
+
+            // Verify Buffer account
+
+            let buffer = instruction_context.try_borrow_instruction_account(2)?;
+            if let UpgradeableLoaderState::Buffer { authority_address } = buffer.get_state()? {
+                if authority_address != authority_key {
+                    ic_logger_msg!(log_collector, "Buffer and upgrade authority don't match");
+                    return Err(InstructionError::IncorrectAuthority);
+                }
+                if !instruction_context.is_instruction_account_signer(6)? {
+                    ic_logger_msg!(log_collector, "Upgrade authority did not sign");
+                    return Err(InstructionError::MissingRequiredSignature);
+                }
+            } else {
+                ic_logger_msg!(log_collector, "Invalid Buffer account");
+                return Err(InstructionError::InvalidArgument);
+            }
+            let buffer_lamports = buffer.get_lamports();
+            let buffer_data_offset = UpgradeableLoaderState::size_of_buffer_metadata();
+            let buffer_data_len = buffer.get_data().len().saturating_sub(buffer_data_offset);
+            if buffer.get_data().len() < UpgradeableLoaderState::size_of_buffer_metadata()
+                || buffer_data_len == 0
+            {
+                ic_logger_msg!(log_collector, "Buffer account too small");
+                return Err(InstructionError::InvalidAccountData);
+            }
+            drop(buffer);
+
+            // Verify ProgramData account
+
+            let programdata = instruction_context.try_borrow_instruction_account(0)?;
+            let programdata_data_offset = UpgradeableLoaderState::size_of_programdata_metadata();
+            let programdata_balance_required =
+                1.max(rent.minimum_balance(programdata.get_data().len()));
+            if programdata.get_data().len()
+                < UpgradeableLoaderState::size_of_programdata(buffer_data_len)
+            {
+                ic_logger_msg!(log_collector, "ProgramData account not large enough");
+                return Err(InstructionError::AccountDataTooSmall);
+            }
+            if programdata.get_lamports().saturating_add(buffer_lamports)
+                < programdata_balance_required
+            {
+                ic_logger_msg!(
+                    log_collector,
+                    "Buffer account balance too low to fund upgrade"
+                );
+                return Err(InstructionError::InsufficientFunds);
+            }
+            if let UpgradeableLoaderState::ProgramData {
+                slot,
+                upgrade_authority_address,
+            } = programdata.get_state()?
+            {
+                if clock.slot == slot {
+                    ic_logger_msg!(log_collector, "Program was deployed in this block already");
+                    return Err(InstructionError::InvalidArgument);
+                }
+                if upgrade_authority_address.is_none() {
+                    ic_logger_msg!(log_collector, "Program not upgradeable");
+                    return Err(InstructionError::Immutable);
+                }
+                if upgrade_authority_address != authority_key {
+                    ic_logger_msg!(log_collector, "Incorrect upgrade authority provided");
+                    return Err(InstructionError::IncorrectAuthority);
+                }
+                if !instruction_context.is_instruction_account_signer(6)? {
+                    ic_logger_msg!(log_collector, "Upgrade authority did not sign");
+                    return Err(InstructionError::MissingRequiredSignature);
+                }
+            } else {
+                ic_logger_msg!(log_collector, "Invalid ProgramData account");
+                return Err(InstructionError::InvalidAccountData);
+            };
+            let programdata_len = programdata.get_data().len();
+            drop(programdata);
+
+            // Load and verify the program bits
+            let buffer = instruction_context.try_borrow_instruction_account(2)?;
+            deploy_program!(
+                invoke_context,
+                &new_program_id,
+                program_id,
+                UpgradeableLoaderState::size_of_program().saturating_add(programdata_len),
+                buffer
+                    .get_data()
+                    .get(buffer_data_offset..)
+                    .ok_or(InstructionError::AccountDataTooSmall)?,
+                clock.slot,
+            );
+            drop(buffer);
+
+            let transaction_context = &invoke_context.transaction_context;
+            let instruction_context = transaction_context.get_current_instruction_context()?;
+
+            // Update the ProgramData account, record the upgraded data, and zero
+            // the rest
+            let mut programdata = instruction_context.try_borrow_instruction_account(0)?;
+            {
+                programdata.set_state(&UpgradeableLoaderState::ProgramData {
+                    slot: clock.slot,
+                    upgrade_authority_address: authority_key,
+                })?;
+                let dst_slice = programdata
+                    .get_data_mut()?
+                    .get_mut(
+                        programdata_data_offset
+                            ..programdata_data_offset.saturating_add(buffer_data_len),
+                    )
+                    .ok_or(InstructionError::AccountDataTooSmall)?;
+                let buffer = instruction_context.try_borrow_instruction_account(2)?;
+                let src_slice = buffer
+                    .get_data()
+                    .get(buffer_data_offset..)
+                    .ok_or(InstructionError::AccountDataTooSmall)?;
+                dst_slice.copy_from_slice(src_slice);
+            }
+            programdata
+                .get_data_mut()?
+                .get_mut(programdata_data_offset.saturating_add(buffer_data_len)..)
+                .ok_or(InstructionError::AccountDataTooSmall)?
+                .fill(0);
+
+            // Fund ProgramData to rent-exemption, spill the rest
+            let mut buffer = instruction_context.try_borrow_instruction_account(2)?;
+            let mut spill = instruction_context.try_borrow_instruction_account(3)?;
+            spill.checked_add_lamports(
+                programdata
+                    .get_lamports()
+                    .saturating_add(buffer_lamports)
+                    .saturating_sub(programdata_balance_required),
+            )?;
+            buffer.set_lamports(0)?;
+            programdata.set_lamports(programdata_balance_required)?;
+            buffer.set_data_length(UpgradeableLoaderState::size_of_buffer(0))?;
+
+            ic_logger_msg!(log_collector, "Upgraded program {:?}", new_program_id);
+        }
+        UpgradeableLoaderInstruction::SetAuthority => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
+            let mut account = instruction_context.try_borrow_instruction_account(0)?;
+            let present_authority_key = instruction_context.get_key_of_instruction_account(1)?;
+            let new_authority = instruction_context.get_key_of_instruction_account(2).ok();
+
+            match account.get_state()? {
+                UpgradeableLoaderState::Buffer { authority_address } => {
+                    if new_authority.is_none() {
+                        ic_logger_msg!(log_collector, "Buffer authority is not optional");
+                        return Err(InstructionError::IncorrectAuthority);
+                    }
+                    if authority_address.is_none() {
+                        ic_logger_msg!(log_collector, "Buffer is immutable");
+                        return Err(InstructionError::Immutable);
+                    }
+                    if authority_address != Some(*present_authority_key) {
+                        ic_logger_msg!(log_collector, "Incorrect buffer authority provided");
+                        return Err(InstructionError::IncorrectAuthority);
+                    }
+                    if !instruction_context.is_instruction_account_signer(1)? {
+                        ic_logger_msg!(log_collector, "Buffer authority did not sign");
+                        return Err(InstructionError::MissingRequiredSignature);
+                    }
+                    account.set_state(&UpgradeableLoaderState::Buffer {
+                        authority_address: new_authority.cloned(),
+                    })?;
+                }
+                UpgradeableLoaderState::ProgramData {
+                    slot,
+                    upgrade_authority_address,
+                } => {
+                    if upgrade_authority_address.is_none() {
+                        ic_logger_msg!(log_collector, "Program not upgradeable");
+                        return Err(InstructionError::Immutable);
+                    }
+                    if upgrade_authority_address != Some(*present_authority_key) {
+                        ic_logger_msg!(log_collector, "Incorrect upgrade authority provided");
+                        return Err(InstructionError::IncorrectAuthority);
+                    }
+                    if !instruction_context.is_instruction_account_signer(1)? {
+                        ic_logger_msg!(log_collector, "Upgrade authority did not sign");
+                        return Err(InstructionError::MissingRequiredSignature);
+                    }
+                    account.set_state(&UpgradeableLoaderState::ProgramData {
+                        slot,
+                        upgrade_authority_address: new_authority.cloned(),
+                    })?;
+                }
+                _ => {
+                    ic_logger_msg!(log_collector, "Account does not support authorities");
+                    return Err(InstructionError::InvalidArgument);
+                }
+            }
+
+            ic_logger_msg!(log_collector, "New authority {:?}", new_authority);
+        }
+        UpgradeableLoaderInstruction::SetAuthorityChecked => {
+            if !invoke_context
+                .get_feature_set()
+                .enable_bpf_loader_set_authority_checked_ix
+            {
+                return Err(InstructionError::InvalidInstructionData);
+            }
+
+            instruction_context.check_number_of_instruction_accounts(3)?;
+            let mut account = instruction_context.try_borrow_instruction_account(0)?;
+            let present_authority_key = instruction_context.get_key_of_instruction_account(1)?;
+            let new_authority_key = instruction_context.get_key_of_instruction_account(2)?;
+
+            match account.get_state()? {
+                UpgradeableLoaderState::Buffer { authority_address } => {
+                    if authority_address.is_none() {
+                        ic_logger_msg!(log_collector, "Buffer is immutable");
+                        return Err(InstructionError::Immutable);
+                    }
+                    if authority_address != Some(*present_authority_key) {
+                        ic_logger_msg!(log_collector, "Incorrect buffer authority provided");
+                        return Err(InstructionError::IncorrectAuthority);
+                    }
+                    if !instruction_context.is_instruction_account_signer(1)? {
+                        ic_logger_msg!(log_collector, "Buffer authority did not sign");
+                        return Err(InstructionError::MissingRequiredSignature);
+                    }
+                    if !instruction_context.is_instruction_account_signer(2)? {
+                        ic_logger_msg!(log_collector, "New authority did not sign");
+                        return Err(InstructionError::MissingRequiredSignature);
+                    }
+                    account.set_state(&UpgradeableLoaderState::Buffer {
+                        authority_address: Some(*new_authority_key),
+                    })?;
+                }
+                UpgradeableLoaderState::ProgramData {
+                    slot,
+                    upgrade_authority_address,
+                } => {
+                    if upgrade_authority_address.is_none() {
+                        ic_logger_msg!(log_collector, "Program not upgradeable");
+                        return Err(InstructionError::Immutable);
+                    }
+                    if upgrade_authority_address != Some(*present_authority_key) {
+                        ic_logger_msg!(log_collector, "Incorrect upgrade authority provided");
+                        return Err(InstructionError::IncorrectAuthority);
+                    }
+                    if !instruction_context.is_instruction_account_signer(1)? {
+                        ic_logger_msg!(log_collector, "Upgrade authority did not sign");
+                        return Err(InstructionError::MissingRequiredSignature);
+                    }
+                    if !instruction_context.is_instruction_account_signer(2)? {
+                        ic_logger_msg!(log_collector, "New authority did not sign");
+                        return Err(InstructionError::MissingRequiredSignature);
+                    }
+                    account.set_state(&UpgradeableLoaderState::ProgramData {
+                        slot,
+                        upgrade_authority_address: Some(*new_authority_key),
+                    })?;
+                }
+                _ => {
+                    ic_logger_msg!(log_collector, "Account does not support authorities");
+                    return Err(InstructionError::InvalidArgument);
+                }
+            }
+
+            ic_logger_msg!(log_collector, "New authority {:?}", new_authority_key);
+        }
+        UpgradeableLoaderInstruction::Close => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
+            if instruction_context.get_index_of_instruction_account_in_transaction(0)?
+                == instruction_context.get_index_of_instruction_account_in_transaction(1)?
+            {
+                ic_logger_msg!(
+                    log_collector,
+                    "Recipient is the same as the account being closed"
+                );
+                return Err(InstructionError::InvalidArgument);
+            }
+            let mut close_account = instruction_context.try_borrow_instruction_account(0)?;
+            let close_key = *close_account.get_key();
+            let close_account_state = close_account.get_state()?;
+            close_account.set_data_length(UpgradeableLoaderState::size_of_uninitialized())?;
+            match close_account_state {
+                UpgradeableLoaderState::Uninitialized => {
+                    let mut recipient_account =
+                        instruction_context.try_borrow_instruction_account(1)?;
+                    recipient_account.checked_add_lamports(close_account.get_lamports())?;
+                    close_account.set_lamports(0)?;
+
+                    ic_logger_msg!(log_collector, "Closed Uninitialized {}", close_key);
+                }
+                UpgradeableLoaderState::Buffer { authority_address } => {
+                    instruction_context.check_number_of_instruction_accounts(3)?;
+                    drop(close_account);
+                    common_close_account(&authority_address, &instruction_context, &log_collector)?;
+
+                    ic_logger_msg!(log_collector, "Closed Buffer {}", close_key);
+                }
+                UpgradeableLoaderState::ProgramData {
+                    slot,
+                    upgrade_authority_address: authority_address,
+                } => {
+                    instruction_context.check_number_of_instruction_accounts(4)?;
+                    drop(close_account);
+                    let program_account = instruction_context.try_borrow_instruction_account(3)?;
+                    let program_key = *program_account.get_key();
+
+                    if !program_account.is_writable() {
+                        ic_logger_msg!(log_collector, "Program account is not writable");
+                        return Err(InstructionError::InvalidArgument);
+                    }
+                    if program_account.get_owner() != program_id {
+                        ic_logger_msg!(log_collector, "Program account not owned by loader");
+                        return Err(InstructionError::IncorrectProgramId);
+                    }
+                    let clock = invoke_context.get_sysvar_cache().get_clock()?;
+                    if clock.slot == slot {
+                        ic_logger_msg!(log_collector, "Program was deployed in this block already");
+                        return Err(InstructionError::InvalidArgument);
+                    }
+
+                    match program_account.get_state()? {
+                        UpgradeableLoaderState::Program {
+                            programdata_address,
+                        } => {
+                            if programdata_address != close_key {
+                                ic_logger_msg!(
+                                    log_collector,
+                                    "ProgramData account does not match ProgramData account"
+                                );
+                                return Err(InstructionError::InvalidArgument);
+                            }
+
+                            drop(program_account);
+                            common_close_account(
+                                &authority_address,
+                                &instruction_context,
+                                &log_collector,
+                            )?;
+                            let clock = invoke_context.get_sysvar_cache().get_clock()?;
+                            invoke_context
+                                .program_cache_for_tx_batch
+                                .store_modified_entry(
+                                    program_key,
+                                    Arc::new(ProgramCacheEntry::new_tombstone(
+                                        clock.slot,
+                                        ProgramCacheEntryOwner::LoaderV3,
+                                        ProgramCacheEntryType::Closed,
+                                    )),
+                                );
+                        }
+                        _ => {
+                            ic_logger_msg!(log_collector, "Invalid Program account");
+                            return Err(InstructionError::InvalidArgument);
+                        }
+                    }
+
+                    ic_logger_msg!(log_collector, "Closed Program {}", program_key);
+                }
+                _ => {
+                    ic_logger_msg!(log_collector, "Account does not support closing");
+                    return Err(InstructionError::InvalidArgument);
+                }
+            }
+        }
+        UpgradeableLoaderInstruction::ExtendProgram { additional_bytes } => {
+            if invoke_context
+                .get_feature_set()
+                .enable_extend_program_checked
+            {
+                ic_logger_msg!(
+                    log_collector,
+                    "ExtendProgram was superseded by ExtendProgramChecked"
+                );
+                return Err(InstructionError::InvalidInstructionData);
+            }
+            common_extend_program(invoke_context, additional_bytes, false)?;
+        }
+        UpgradeableLoaderInstruction::ExtendProgramChecked { additional_bytes } => {
+            if !invoke_context
+                .get_feature_set()
+                .enable_extend_program_checked
+            {
+                return Err(InstructionError::InvalidInstructionData);
+            }
+            common_extend_program(invoke_context, additional_bytes, true)?;
+        }
+        UpgradeableLoaderInstruction::Migrate => {
+            if !invoke_context.get_feature_set().enable_loader_v4 {
+                return Err(InstructionError::InvalidInstructionData);
+            }
+
+            instruction_context.check_number_of_instruction_accounts(3)?;
+            let programdata_address = *instruction_context.get_key_of_instruction_account(0)?;
+            let program_address = *instruction_context.get_key_of_instruction_account(1)?;
+            let provided_authority_address =
+                *instruction_context.get_key_of_instruction_account(2)?;
+            let clock_slot = invoke_context
+                .get_sysvar_cache()
+                .get_clock()
+                .map(|clock| clock.slot)?;
+
+            // Verify ProgramData account
+            let programdata = instruction_context.try_borrow_instruction_account(0)?;
+            if !programdata.is_writable() {
+                ic_logger_msg!(log_collector, "ProgramData account not writeable");
+                return Err(InstructionError::InvalidArgument);
+            }
+            let (program_len, upgrade_authority_address) =
+                if let Ok(UpgradeableLoaderState::ProgramData {
+                    slot,
+                    upgrade_authority_address,
+                }) = programdata.get_state()
+                {
+                    if clock_slot == slot {
+                        ic_logger_msg!(log_collector, "Program was deployed in this block already");
+                        return Err(InstructionError::InvalidArgument);
+                    }
+                    (
+                        programdata
+                            .get_data()
+                            .len()
+                            .saturating_sub(UpgradeableLoaderState::size_of_programdata_metadata()),
+                        upgrade_authority_address,
+                    )
+                } else {
+                    (0, None)
+                };
+            let programdata_funds = programdata.get_lamports();
+            drop(programdata);
+
+            // Verify authority signature
+            if !migration_authority::check_id(&provided_authority_address)
+                && provided_authority_address
+                    != upgrade_authority_address.unwrap_or(program_address)
+            {
+                ic_logger_msg!(log_collector, "Incorrect migration authority provided");
+                return Err(InstructionError::IncorrectAuthority);
+            }
+            if !instruction_context.is_instruction_account_signer(2)? {
+                ic_logger_msg!(log_collector, "Migration authority did not sign");
+                return Err(InstructionError::MissingRequiredSignature);
+            }
+
+            // Verify Program account
+            let mut program = instruction_context.try_borrow_instruction_account(1)?;
+            if !program.is_writable() {
+                ic_logger_msg!(log_collector, "Program account not writeable");
+                return Err(InstructionError::InvalidArgument);
+            }
+            if program.get_owner() != program_id {
+                ic_logger_msg!(log_collector, "Program account not owned by loader");
+                return Err(InstructionError::IncorrectProgramId);
+            }
+            if let UpgradeableLoaderState::Program {
+                programdata_address: stored_programdata_address,
+            } = program.get_state()?
+            {
+                if programdata_address != stored_programdata_address {
+                    ic_logger_msg!(log_collector, "Program and ProgramData account mismatch");
+                    return Err(InstructionError::InvalidArgument);
+                }
+            } else {
+                ic_logger_msg!(log_collector, "Invalid Program account");
+                return Err(InstructionError::InvalidAccountData);
+            }
+            program.set_data_from_slice(&[])?;
+            program.checked_add_lamports(programdata_funds)?;
+            program.set_owner(&loader_v4::id().to_bytes())?;
+            drop(program);
+
+            let mut programdata = instruction_context.try_borrow_instruction_account(0)?;
+            programdata.set_lamports(0)?;
+            drop(programdata);
+
+            if program_len == 0 {
+                invoke_context
+                    .program_cache_for_tx_batch
+                    .store_modified_entry(
+                        program_address,
+                        Arc::new(ProgramCacheEntry::new_tombstone(
+                            clock_slot,
+                            ProgramCacheEntryOwner::LoaderV4,
+                            ProgramCacheEntryType::Closed,
+                        )),
+                    );
+            } else {
+                invoke_context.native_invoke(
+                    solana_loader_v4_interface::instruction::set_program_length(
+                        &program_address,
+                        &provided_authority_address,
+                        program_len as u32,
+                        &program_address,
+                    ),
+                    &[],
+                )?;
+
+                invoke_context.native_invoke(
+                    solana_loader_v4_interface::instruction::copy(
+                        &program_address,
+                        &provided_authority_address,
+                        &programdata_address,
+                        0,
+                        0,
+                        program_len as u32,
+                    ),
+                    &[],
+                )?;
+
+                invoke_context.native_invoke(
+                    solana_loader_v4_interface::instruction::deploy(
+                        &program_address,
+                        &provided_authority_address,
+                    ),
+                    &[],
+                )?;
+
+                if upgrade_authority_address.is_none() {
+                    invoke_context.native_invoke(
+                        solana_loader_v4_interface::instruction::finalize(
+                            &program_address,
+                            &provided_authority_address,
+                            &program_address,
+                        ),
+                        &[],
+                    )?;
+                } else if migration_authority::check_id(&provided_authority_address) {
+                    invoke_context.native_invoke(
+                        solana_loader_v4_interface::instruction::transfer_authority(
+                            &program_address,
+                            &provided_authority_address,
+                            &upgrade_authority_address.unwrap(),
+                        ),
+                        &[],
+                    )?;
+                }
+            }
+
+            let transaction_context = &invoke_context.transaction_context;
+            let instruction_context = transaction_context.get_current_instruction_context()?;
+            let mut programdata = instruction_context.try_borrow_instruction_account(0)?;
+            programdata.set_data_from_slice(&[])?;
+            drop(programdata);
+
+            ic_logger_msg!(log_collector, "Migrated program {:?}", &program_address);
+        }
+    }
+
+    Ok(())
+}
+
+fn common_extend_program(
+    invoke_context: &mut InvokeContext,
+    additional_bytes: u32,
+    check_authority: bool,
+) -> Result<(), InstructionError> {
+    let log_collector = invoke_context.get_log_collector();
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let program_id = instruction_context.get_program_key()?;
+
+    const PROGRAM_DATA_ACCOUNT_INDEX: IndexOfAccount = 0;
+    const PROGRAM_ACCOUNT_INDEX: IndexOfAccount = 1;
+    const AUTHORITY_ACCOUNT_INDEX: IndexOfAccount = 2;
+    // The unused `system_program_account_index` is 3 if `check_authority` and 2 otherwise.
+    let optional_payer_account_index = if check_authority { 4 } else { 3 };
+
+    if additional_bytes == 0 {
+        ic_logger_msg!(log_collector, "Additional bytes must be greater than 0");
+        return Err(InstructionError::InvalidInstructionData);
+    }
+
+    let programdata_account =
+        instruction_context.try_borrow_instruction_account(PROGRAM_DATA_ACCOUNT_INDEX)?;
+    let programdata_key = *programdata_account.get_key();
+
+    if program_id != programdata_account.get_owner() {
+        ic_logger_msg!(log_collector, "ProgramData owner is invalid");
+        return Err(InstructionError::InvalidAccountOwner);
+    }
+    if !programdata_account.is_writable() {
+        ic_logger_msg!(log_collector, "ProgramData is not writable");
+        return Err(InstructionError::InvalidArgument);
+    }
+
+    let program_account =
+        instruction_context.try_borrow_instruction_account(PROGRAM_ACCOUNT_INDEX)?;
+    if !program_account.is_writable() {
+        ic_logger_msg!(log_collector, "Program account is not writable");
+        return Err(InstructionError::InvalidArgument);
+    }
+    if program_account.get_owner() != program_id {
+        ic_logger_msg!(log_collector, "Program account not owned by loader");
+        return Err(InstructionError::InvalidAccountOwner);
+    }
+    let program_key = *program_account.get_key();
+    match program_account.get_state()? {
+        UpgradeableLoaderState::Program {
+            programdata_address,
+        } => {
+            if programdata_address != programdata_key {
+                ic_logger_msg!(
+                    log_collector,
+                    "Program account does not match ProgramData account"
+                );
+                return Err(InstructionError::InvalidArgument);
+            }
+        }
+        _ => {
+            ic_logger_msg!(log_collector, "Invalid Program account");
+            return Err(InstructionError::InvalidAccountData);
+        }
+    }
+    drop(program_account);
+
+    let old_len = programdata_account.get_data().len();
+    let new_len = old_len.saturating_add(additional_bytes as usize);
+    if new_len > MAX_PERMITTED_DATA_LENGTH as usize {
+        ic_logger_msg!(
+            log_collector,
+            "Extended ProgramData length of {} bytes exceeds max account data length of {} bytes",
+            new_len,
+            MAX_PERMITTED_DATA_LENGTH
+        );
+        return Err(InstructionError::InvalidRealloc);
+    }
+
+    let clock_slot = invoke_context
+        .get_sysvar_cache()
+        .get_clock()
+        .map(|clock| clock.slot)?;
+
+    let upgrade_authority_address = if let UpgradeableLoaderState::ProgramData {
+        slot,
+        upgrade_authority_address,
+    } = programdata_account.get_state()?
+    {
+        if clock_slot == slot {
+            ic_logger_msg!(log_collector, "Program was extended in this block already");
+            return Err(InstructionError::InvalidArgument);
+        }
+
+        if upgrade_authority_address.is_none() {
+            ic_logger_msg!(
+                log_collector,
+                "Cannot extend ProgramData accounts that are not upgradeable"
+            );
+            return Err(InstructionError::Immutable);
+        }
+
+        if check_authority {
+            let authority_key =
+                Some(*instruction_context.get_key_of_instruction_account(AUTHORITY_ACCOUNT_INDEX)?);
+            if upgrade_authority_address != authority_key {
+                ic_logger_msg!(log_collector, "Incorrect upgrade authority provided");
+                return Err(InstructionError::IncorrectAuthority);
+            }
+            if !instruction_context.is_instruction_account_signer(AUTHORITY_ACCOUNT_INDEX)? {
+                ic_logger_msg!(log_collector, "Upgrade authority did not sign");
+                return Err(InstructionError::MissingRequiredSignature);
+            }
+        }
+
+        upgrade_authority_address
+    } else {
+        ic_logger_msg!(log_collector, "ProgramData state is invalid");
+        return Err(InstructionError::InvalidAccountData);
+    };
+
+    let required_payment = {
+        let balance = programdata_account.get_lamports();
+        let rent = invoke_context.get_sysvar_cache().get_rent()?;
+        let min_balance = rent.minimum_balance(new_len).max(1);
+        min_balance.saturating_sub(balance)
+    };
+
+    // Borrowed accounts need to be dropped before native_invoke
+    drop(programdata_account);
+
+    // Dereference the program ID to prevent overlapping mutable/immutable borrow of invoke context
+    let program_id = *program_id;
+    if required_payment > 0 {
+        let payer_key =
+            *instruction_context.get_key_of_instruction_account(optional_payer_account_index)?;
+
+        invoke_context.native_invoke(
+            system_instruction::transfer(&payer_key, &programdata_key, required_payment),
+            &[],
+        )?;
+    }
+
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let mut programdata_account =
+        instruction_context.try_borrow_instruction_account(PROGRAM_DATA_ACCOUNT_INDEX)?;
+    programdata_account.set_data_length(new_len)?;
+
+    let programdata_data_offset = UpgradeableLoaderState::size_of_programdata_metadata();
+
+    deploy_program!(
+        invoke_context,
+        &program_key,
+        &program_id,
+        UpgradeableLoaderState::size_of_program().saturating_add(new_len),
+        programdata_account
+            .get_data()
+            .get(programdata_data_offset..)
+            .ok_or(InstructionError::AccountDataTooSmall)?,
+        clock_slot,
+    );
+    drop(programdata_account);
+
+    let mut programdata_account =
+        instruction_context.try_borrow_instruction_account(PROGRAM_DATA_ACCOUNT_INDEX)?;
+    programdata_account.set_state(&UpgradeableLoaderState::ProgramData {
+        slot: clock_slot,
+        upgrade_authority_address,
+    })?;
+
+    ic_logger_msg!(
+        log_collector,
+        "Extended ProgramData account by {} bytes",
+        additional_bytes
+    );
+
+    Ok(())
+}
+
+fn common_close_account(
+    authority_address: &Option<Pubkey>,
+    instruction_context: &InstructionContext,
+    log_collector: &Option<Rc<RefCell<LogCollector>>>,
+) -> Result<(), InstructionError> {
+    if authority_address.is_none() {
+        ic_logger_msg!(log_collector, "Account is immutable");
+        return Err(InstructionError::Immutable);
+    }
+    if *authority_address != Some(*instruction_context.get_key_of_instruction_account(2)?) {
+        ic_logger_msg!(log_collector, "Incorrect authority provided");
+        return Err(InstructionError::IncorrectAuthority);
+    }
+    if !instruction_context.is_instruction_account_signer(2)? {
+        ic_logger_msg!(log_collector, "Authority did not sign");
+        return Err(InstructionError::MissingRequiredSignature);
+    }
+
+    let mut close_account = instruction_context.try_borrow_instruction_account(0)?;
+    let mut recipient_account = instruction_context.try_borrow_instruction_account(1)?;
+
+    recipient_account.checked_add_lamports(close_account.get_lamports())?;
+    close_account.set_lamports(0)?;
+    close_account.set_state(&UpgradeableLoaderState::Uninitialized)?;
+    Ok(())
+}
+
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+fn execute<'a, 'b: 'a>(
+    executable: &'a Executable<InvokeContext<'static, 'static>>,
+    invoke_context: &'a mut InvokeContext<'b, 'b>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // We dropped the lifetime tracking in the Executor by setting it to 'static,
+    // thus we need to reintroduce the correct lifetime of InvokeContext here again.
+    let executable = unsafe {
+        mem::transmute::<
+            &'a Executable<InvokeContext<'static, 'static>>,
+            &'a Executable<InvokeContext<'b, 'b>>,
+        >(executable)
+    };
+    let log_collector = invoke_context.get_log_collector();
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let program_id = *instruction_context.get_program_key()?;
+    let is_loader_deprecated =
+        instruction_context.get_program_owner()? == bpf_loader_deprecated::id();
+    #[cfg(any(target_os = "windows", not(target_arch = "x86_64")))]
+    let use_jit = false;
+    #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
+    let use_jit = executable.get_compiled_program().is_some();
+    let stricter_abi_and_runtime_constraints = invoke_context
+        .get_feature_set()
+        .stricter_abi_and_runtime_constraints;
+    let account_data_direct_mapping = invoke_context.get_feature_set().account_data_direct_mapping;
+    let mask_out_rent_epoch_in_vm_serialization = invoke_context
+        .get_feature_set()
+        .mask_out_rent_epoch_in_vm_serialization;
+    let provide_instruction_data_offset_in_vm_r2 = invoke_context
+        .get_feature_set()
+        .provide_instruction_data_offset_in_vm_r2;
+
+    let mut serialize_time = Measure::start("serialize");
+    let (parameter_bytes, regions, accounts_metadata, instruction_data_offset) =
+        serialization::serialize_parameters(
+            &instruction_context,
+            stricter_abi_and_runtime_constraints,
+            account_data_direct_mapping,
+            mask_out_rent_epoch_in_vm_serialization,
+        )?;
+    serialize_time.stop();
+
+    // save the account addresses so in case we hit an AccessViolation error we
+    // can map to a more specific error
+    let account_region_addrs = accounts_metadata
+        .iter()
+        .map(|m| {
+            let vm_end = m
+                .vm_data_addr
+                .saturating_add(m.original_data_len as u64)
+                .saturating_add(if !is_loader_deprecated {
+                    MAX_PERMITTED_DATA_INCREASE as u64
+                } else {
+                    0
+                });
+            m.vm_data_addr..vm_end
+        })
+        .collect::<Vec<_>>();
+
+    let mut create_vm_time = Measure::start("create_vm");
+    let execution_result = {
+        let compute_meter_prev = invoke_context.get_remaining();
+        create_vm!(vm, executable, regions, accounts_metadata, invoke_context);
+        let (mut vm, stack, heap) = match vm {
+            Ok(info) => info,
+            Err(e) => {
+                ic_logger_msg!(log_collector, "Failed to create SBF VM: {}", e);
+                return Err(Box::new(InstructionError::ProgramEnvironmentSetupFailure));
+            }
+        };
+        create_vm_time.stop();
+
+        vm.context_object_pointer.execute_time = Some(Measure::start("execute"));
+        vm.registers[1] = ebpf::MM_INPUT_START;
+
+        // SIMD-0321: Provide offset to instruction data in VM register 2.
+        if provide_instruction_data_offset_in_vm_r2 {
+            vm.registers[2] = instruction_data_offset as u64;
+        }
+        let (compute_units_consumed, result) = vm.execute_program(executable, !use_jit);
+        let register_trace = std::mem::take(&mut vm.register_trace);
+        MEMORY_POOL.with_borrow_mut(|memory_pool| {
+            memory_pool.put_stack(stack);
+            memory_pool.put_heap(heap);
+            debug_assert!(memory_pool.stack_len() <= MAX_INSTRUCTION_STACK_DEPTH);
+            debug_assert!(memory_pool.heap_len() <= MAX_INSTRUCTION_STACK_DEPTH);
+        });
+        drop(vm);
+        invoke_context.insert_register_trace(register_trace);
+        if let Some(execute_time) = invoke_context.execute_time.as_mut() {
+            execute_time.stop();
+            invoke_context.timings.execute_us += execute_time.as_us();
+        }
+
+        ic_logger_msg!(
+            log_collector,
+            "Program {} consumed {} of {} compute units",
+            &program_id,
+            compute_units_consumed,
+            compute_meter_prev
+        );
+        let (_returned_from_program_id, return_data) =
+            invoke_context.transaction_context.get_return_data();
+        if !return_data.is_empty() {
+            stable_log::program_return(&log_collector, &program_id, return_data);
+        }
+        match result {
+            ProgramResult::Ok(status) if status != SUCCESS => {
+                let error: InstructionError = status.into();
+                Err(Box::new(error) as Box<dyn std::error::Error>)
+            }
+            ProgramResult::Err(mut error) => {
+                // Don't clean me up!!
+                // This feature is active on all networks, but we still toggle
+                // it off during fuzzing.
+                if invoke_context
+                    .get_feature_set()
+                    .deplete_cu_meter_on_vm_failure
+                    && !matches!(error, EbpfError::SyscallError(_))
+                {
+                    // when an exception is thrown during the execution of a
+                    // Basic Block (e.g., a null memory dereference or other
+                    // faults), determining the exact number of CUs consumed
+                    // up to the point of failure requires additional effort
+                    // and is unnecessary since these cases are rare.
+                    //
+                    // In order to simplify CU tracking, simply consume all
+                    // remaining compute units so that the block cost
+                    // tracker uses the full requested compute unit cost for
+                    // this failed transaction.
+                    invoke_context.consume(invoke_context.get_remaining());
+                }
+
+                if stricter_abi_and_runtime_constraints {
+                    if let EbpfError::SyscallError(err) = error {
+                        error = err
+                            .downcast::<EbpfError>()
+                            .map(|err| *err)
+                            .unwrap_or_else(EbpfError::SyscallError);
+                    }
+                    if let EbpfError::AccessViolation(access_type, vm_addr, len, _section_name) =
+                        error
+                    {
+                        // If stricter_abi_and_runtime_constraints is enabled and a program tries to write to a readonly
+                        // region we'll get a memory access violation. Map it to a more specific
+                        // error so it's easier for developers to see what happened.
+                        if let Some((instruction_account_index, vm_addr_range)) =
+                            account_region_addrs
+                                .iter()
+                                .enumerate()
+                                .find(|(_, vm_addr_range)| vm_addr_range.contains(&vm_addr))
+                        {
+                            let transaction_context = &invoke_context.transaction_context;
+                            let instruction_context =
+                                transaction_context.get_current_instruction_context()?;
+                            let account = instruction_context.try_borrow_instruction_account(
+                                instruction_account_index as IndexOfAccount,
+                            )?;
+                            if vm_addr.saturating_add(len) <= vm_addr_range.end {
+                                // The access was within the range of the accounts address space,
+                                // but it might not be within the range of the actual data.
+                                let is_access_outside_of_data = vm_addr
+                                    .saturating_add(len)
+                                    .saturating_sub(vm_addr_range.start)
+                                    as usize
+                                    > account.get_data().len();
+                                error = EbpfError::SyscallError(Box::new(
+                                    #[allow(deprecated)]
+                                    match access_type {
+                                        AccessType::Store => {
+                                            if let Err(err) = account.can_data_be_changed() {
+                                                err
+                                            } else {
+                                                // The store was allowed but failed,
+                                                // thus it must have been an attempt to grow the account.
+                                                debug_assert!(is_access_outside_of_data);
+                                                InstructionError::InvalidRealloc
+                                            }
+                                        }
+                                        AccessType::Load => {
+                                            // Loads should only fail when they are outside of the account data.
+                                            debug_assert!(is_access_outside_of_data);
+                                            if account.can_data_be_changed().is_err() {
+                                                // Load beyond readonly account data happened because the program
+                                                // expected more data than there actually is.
+                                                InstructionError::AccountDataTooSmall
+                                            } else {
+                                                // Load beyond writable account data also attempted to grow.
+                                                InstructionError::InvalidRealloc
+                                            }
+                                        }
+                                    },
+                                ));
+                            }
+                        }
+                    }
+                }
+                Err(if let EbpfError::SyscallError(err) = error {
+                    err
+                } else {
+                    error.into()
+                })
+            }
+            _ => Ok(()),
+        }
+    };
+
+    fn deserialize_parameters(
+        invoke_context: &mut InvokeContext,
+        parameter_bytes: &[u8],
+        stricter_abi_and_runtime_constraints: bool,
+        account_data_direct_mapping: bool,
+    ) -> Result<(), InstructionError> {
+        serialization::deserialize_parameters(
+            &invoke_context
+                .transaction_context
+                .get_current_instruction_context()?,
+            stricter_abi_and_runtime_constraints,
+            account_data_direct_mapping,
+            parameter_bytes,
+            &invoke_context.get_syscall_context()?.accounts_metadata,
+        )
+    }
+
+    let mut deserialize_time = Measure::start("deserialize");
+    let execute_or_deserialize_result = execution_result.and_then(|_| {
+        deserialize_parameters(
+            invoke_context,
+            parameter_bytes.as_slice(),
+            stricter_abi_and_runtime_constraints,
+            account_data_direct_mapping,
+        )
+        .map_err(|error| Box::new(error) as Box<dyn std::error::Error>)
+    });
+    deserialize_time.stop();
+
+    // Update the timings
+    invoke_context.timings.serialize_us += serialize_time.as_us();
+    invoke_context.timings.create_vm_us += create_vm_time.as_us();
+    invoke_context.timings.deserialize_us += deserialize_time.as_us();
+
+    execute_or_deserialize_result
+}
+
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+mod test_utils {
+    #[cfg(feature = "svm-internal")]
+    use {
+        super::*, agave_syscalls::create_program_runtime_environment_v1,
+        solana_account::ReadableAccount, solana_loader_v4_interface::state::LoaderV4State,
+        solana_sdk_ids::loader_v4,
+    };
+
+    #[cfg(feature = "svm-internal")]
+    fn check_loader_id(id: &Pubkey) -> bool {
+        bpf_loader::check_id(id)
+            || bpf_loader_deprecated::check_id(id)
+            || bpf_loader_upgradeable::check_id(id)
+            || loader_v4::check_id(id)
+    }
+
+    #[cfg(feature = "svm-internal")]
+    #[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+    fn load_all_invoked_programs(invoke_context: &mut InvokeContext) {
+        let mut load_program_metrics = LoadProgramMetrics::default();
+        let program_runtime_environment = create_program_runtime_environment_v1(
+            invoke_context.get_feature_set(),
+            invoke_context.get_compute_budget(),
+            false, /* deployment */
+            false, /* debugging_features */
+        );
+        let program_runtime_environment = Arc::new(program_runtime_environment.unwrap());
+        let num_accounts = invoke_context.transaction_context.get_number_of_accounts();
+        for index in 0..num_accounts {
+            let account = invoke_context
+                .transaction_context
+                .accounts()
+                .try_borrow(index)
+                .expect("Failed to get the account");
+
+            let owner = account.owner();
+            if check_loader_id(owner) {
+                let programdata_data_offset = if loader_v4::check_id(owner) {
+                    LoaderV4State::program_data_offset()
+                } else {
+                    0
+                };
+                let pubkey = invoke_context
+                    .transaction_context
+                    .get_key_of_account_at_index(index)
+                    .expect("Failed to get account key");
+
+                if let Ok(loaded_program) = load_program_from_bytes(
+                    None,
+                    &mut load_program_metrics,
+                    account
+                        .data()
+                        .get(programdata_data_offset.min(account.data().len())..)
+                        .unwrap(),
+                    owner,
+                    account.data().len(),
+                    0,
+                    program_runtime_environment.clone(),
+                    false,
+                ) {
+                    invoke_context
+                        .program_cache_for_tx_batch
+                        .store_modified_entry(*pubkey, Arc::new(loaded_program));
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        assert_matches::assert_matches,
+        rand::Rng,
+        solana_account::{
+            create_account_shared_data_for_test as create_account_for_test, state_traits::StateMut,
+            AccountSharedData, ReadableAccount, WritableAccount,
+        },
+        solana_clock::Clock,
+        solana_epoch_schedule::EpochSchedule,
+        solana_instruction::{error::InstructionError, AccountMeta},
+        solana_program_runtime::{
+            invoke_context::mock_process_instruction, with_mock_invoke_context,
+        },
+        solana_pubkey::Pubkey,
+        solana_rent::Rent,
+        solana_sdk_ids::{system_program, sysvar},
+        std::{fs::File, io::Read, ops::Range, sync::atomic::AtomicU64},
+    };
+
+    fn process_instruction(
+        loader_id: &Pubkey,
+        program_index: Option<IndexOfAccount>,
+        instruction_data: &[u8],
+        transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+        instruction_accounts: Vec<AccountMeta>,
+        expected_result: Result<(), InstructionError>,
+    ) -> Vec<AccountSharedData> {
+        mock_process_instruction(
+            loader_id,
+            program_index,
+            instruction_data,
+            transaction_accounts,
+            instruction_accounts,
+            expected_result,
+            Entrypoint::vm,
+            |invoke_context| {
+                test_utils::load_all_invoked_programs(invoke_context);
+            },
+            |_invoke_context| {},
+        )
+    }
+
+    fn load_program_account_from_elf(loader_id: &Pubkey, path: &str) -> AccountSharedData {
+        let mut file = File::open(path).expect("file open failed");
+        let mut elf = Vec::new();
+        file.read_to_end(&mut elf).unwrap();
+        let rent = Rent::default();
+        let mut program_account =
+            AccountSharedData::new(rent.minimum_balance(elf.len()), 0, loader_id);
+        program_account.set_data(elf);
+        program_account.set_executable(true);
+        program_account
+    }
+
+    #[test]
+    fn test_bpf_loader_invoke_main() {
+        let loader_id = bpf_loader::id();
+        let program_id = Pubkey::new_unique();
+        let program_account =
+            load_program_account_from_elf(&loader_id, "test_elfs/out/sbpfv3_return_ok.so");
+        let parameter_id = Pubkey::new_unique();
+        let parameter_account = AccountSharedData::new(1, 0, &loader_id);
+        let parameter_meta = AccountMeta {
+            pubkey: parameter_id,
+            is_signer: false,
+            is_writable: false,
+        };
+
+        // Case: No program account
+        process_instruction(
+            &loader_id,
+            None,
+            &[],
+            Vec::new(),
+            Vec::new(),
+            Err(InstructionError::UnsupportedProgramId),
+        );
+
+        // Case: Only a program account
+        process_instruction(
+            &loader_id,
+            Some(0),
+            &[],
+            vec![(program_id, program_account.clone())],
+            Vec::new(),
+            Ok(()),
+        );
+
+        // Case: With program and parameter account
+        process_instruction(
+            &loader_id,
+            Some(0),
+            &[],
+            vec![
+                (program_id, program_account.clone()),
+                (parameter_id, parameter_account.clone()),
+            ],
+            vec![parameter_meta.clone()],
+            Ok(()),
+        );
+
+        // Case: With duplicate accounts
+        process_instruction(
+            &loader_id,
+            Some(0),
+            &[],
+            vec![
+                (program_id, program_account.clone()),
+                (parameter_id, parameter_account.clone()),
+            ],
+            vec![parameter_meta.clone(), parameter_meta],
+            Ok(()),
+        );
+
+        // Case: limited budget
+        mock_process_instruction(
+            &loader_id,
+            Some(0),
+            &[],
+            vec![(program_id, program_account)],
+            Vec::new(),
+            Err(InstructionError::ProgramFailedToComplete),
+            Entrypoint::vm,
+            |invoke_context| {
+                invoke_context.mock_set_remaining(0);
+                test_utils::load_all_invoked_programs(invoke_context);
+            },
+            |_invoke_context| {},
+        );
+
+        // Case: Account not a program
+        mock_process_instruction(
+            &loader_id,
+            Some(0),
+            &[],
+            vec![(program_id, parameter_account.clone())],
+            Vec::new(),
+            Err(InstructionError::UnsupportedProgramId),
+            Entrypoint::vm,
+            |invoke_context| {
+                test_utils::load_all_invoked_programs(invoke_context);
+            },
+            |_invoke_context| {},
+        );
+        process_instruction(
+            &loader_id,
+            Some(0),
+            &[],
+            vec![(program_id, parameter_account)],
+            Vec::new(),
+            Err(InstructionError::UnsupportedProgramId),
+        );
+    }
+
+    #[test]
+    fn test_bpf_loader_serialize_unaligned() {
+        let loader_id = bpf_loader_deprecated::id();
+        let program_id = Pubkey::new_unique();
+        let program_account =
+            load_program_account_from_elf(&loader_id, "test_elfs/out/noop_unaligned.so");
+        let parameter_id = Pubkey::new_unique();
+        let parameter_account = AccountSharedData::new(1, 0, &loader_id);
+        let parameter_meta = AccountMeta {
+            pubkey: parameter_id,
+            is_signer: false,
+            is_writable: false,
+        };
+
+        // Case: With program and parameter account
+        process_instruction(
+            &loader_id,
+            Some(0),
+            &[],
+            vec![
+                (program_id, program_account.clone()),
+                (parameter_id, parameter_account.clone()),
+            ],
+            vec![parameter_meta.clone()],
+            Ok(()),
+        );
+
+        // Case: With duplicate accounts
+        process_instruction(
+            &loader_id,
+            Some(0),
+            &[],
+            vec![
+                (program_id, program_account),
+                (parameter_id, parameter_account),
+            ],
+            vec![parameter_meta.clone(), parameter_meta],
+            Ok(()),
+        );
+    }
+
+    #[test]
+    fn test_bpf_loader_serialize_aligned() {
+        let loader_id = bpf_loader::id();
+        let program_id = Pubkey::new_unique();
+        let program_account =
+            load_program_account_from_elf(&loader_id, "test_elfs/out/noop_aligned.so");
+        let parameter_id = Pubkey::new_unique();
+        let parameter_account = AccountSharedData::new(1, 0, &loader_id);
+        let parameter_meta = AccountMeta {
+            pubkey: parameter_id,
+            is_signer: false,
+            is_writable: false,
+        };
+
+        // Case: With program and parameter account
+        process_instruction(
+            &loader_id,
+            Some(0),
+            &[],
+            vec![
+                (program_id, program_account.clone()),
+                (parameter_id, parameter_account.clone()),
+            ],
+            vec![parameter_meta.clone()],
+            Ok(()),
+        );
+
+        // Case: With duplicate accounts
+        process_instruction(
+            &loader_id,
+            Some(0),
+            &[],
+            vec![
+                (program_id, program_account),
+                (parameter_id, parameter_account),
+            ],
+            vec![parameter_meta.clone(), parameter_meta],
+            Ok(()),
+        );
+    }
+
+    #[test]
+    fn test_bpf_loader_upgradeable_initialize_buffer() {
+        let loader_id = bpf_loader_upgradeable::id();
+        let buffer_address = Pubkey::new_unique();
+        let buffer_account =
+            AccountSharedData::new(1, UpgradeableLoaderState::size_of_buffer(9), &loader_id);
+        let authority_address = Pubkey::new_unique();
+        let authority_account =
+            AccountSharedData::new(1, UpgradeableLoaderState::size_of_buffer(9), &loader_id);
+        let instruction_data =
+            bincode::serialize(&UpgradeableLoaderInstruction::InitializeBuffer).unwrap();
+        let instruction_accounts = vec![
+            AccountMeta {
+                pubkey: buffer_address,
+                is_signer: false,
+                is_writable: true,
+            },
+            AccountMeta {
+                pubkey: authority_address,
+                is_signer: false,
+                is_writable: false,
+            },
+        ];
+
+        // Case: Success
+        let accounts = process_instruction(
+            &loader_id,
+            None,
+            &instruction_data,
+            vec![
+                (buffer_address, buffer_account),
+                (authority_address, authority_account),
+            ],
+            instruction_accounts.clone(),
+            Ok(()),
+        );
+        let state: UpgradeableLoaderState = accounts.first().unwrap().state().unwrap();
+        assert_eq!(
+            state,
+            UpgradeableLoaderState::Buffer {
+                authority_address: Some(authority_address)
+            }
+        );
+
+        // Case: Already initialized
+        let accounts = process_instruction(
+            &loader_id,
+            None,
+            &instruction_data,
+            vec![
+                (buffer_address, accounts.first().unwrap().clone()),
+                (authority_address, accounts.get(1).unwrap().clone()),
+            ],
+            instruction_accounts,
+            Err(InstructionError::AccountAlreadyInitialized),
+        );
+        let state: UpgradeableLoaderState = accounts.first().unwrap().state().unwrap();
+        assert_eq!(
+            state,
+            UpgradeableLoaderState::Buffer {
+                authority_address: Some(authority_address)
+            }
+        );
+    }
+
+    #[test]
+    fn test_bpf_loader_upgradeable_write() {
+        let loader_id = bpf_loader_upgradeable::id();
+        let buffer_address = Pubkey::new_unique();
+        let mut buffer_account =
+            AccountSharedData::new(1, UpgradeableLoaderState::size_of_buffer(9), &loader_id);
+        let instruction_accounts = vec![
+            AccountMeta {
+                pubkey: buffer_address,
+                is_signer: false,
+                is_writable: true,
+            },
+            AccountMeta {
+                pubkey: buffer_address,
+                is_signer: true,
+                is_writable: false,
+            },
+        ];
+
+        // Case: Not initialized
+        let instruction = bincode::serialize(&UpgradeableLoaderInstruction::Write {
+            offset: 0,
+            bytes: vec![42; 9],
+        })
+        .unwrap();
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![(buffer_address, buffer_account.clone())],
+            instruction_accounts.clone(),
+            Err(InstructionError::InvalidAccountData),
+        );
+
+        // Case: Write entire buffer
+        let instruction = bincode::serialize(&UpgradeableLoaderInstruction::Write {
+            offset: 0,
+            bytes: vec![42; 9],
+        })
+        .unwrap();
+        buffer_account
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(buffer_address),
+            })
+            .unwrap();
+        let accounts = process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![(buffer_address, buffer_account.clone())],
+            instruction_accounts.clone(),
+            Ok(()),
+        );
+        let state: UpgradeableLoaderState = accounts.first().unwrap().state().unwrap();
+        assert_eq!(
+            state,
+            UpgradeableLoaderState::Buffer {
+                authority_address: Some(buffer_address)
+            }
+        );
+        assert_eq!(
+            &accounts
+                .first()
+                .unwrap()
+                .data()
+                .get(UpgradeableLoaderState::size_of_buffer_metadata()..)
+                .unwrap(),
+            &[42; 9]
+        );
+
+        // Case: Write portion of the buffer
+        let instruction = bincode::serialize(&UpgradeableLoaderInstruction::Write {
+            offset: 3,
+            bytes: vec![42; 6],
+        })
+        .unwrap();
+        let mut buffer_account =
+            AccountSharedData::new(1, UpgradeableLoaderState::size_of_buffer(9), &loader_id);
+        buffer_account
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(buffer_address),
+            })
+            .unwrap();
+        let accounts = process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![(buffer_address, buffer_account.clone())],
+            instruction_accounts.clone(),
+            Ok(()),
+        );
+        let state: UpgradeableLoaderState = accounts.first().unwrap().state().unwrap();
+        assert_eq!(
+            state,
+            UpgradeableLoaderState::Buffer {
+                authority_address: Some(buffer_address)
+            }
+        );
+        assert_eq!(
+            &accounts
+                .first()
+                .unwrap()
+                .data()
+                .get(UpgradeableLoaderState::size_of_buffer_metadata()..)
+                .unwrap(),
+            &[0, 0, 0, 42, 42, 42, 42, 42, 42]
+        );
+
+        // Case: overflow size
+        let instruction = bincode::serialize(&UpgradeableLoaderInstruction::Write {
+            offset: 0,
+            bytes: vec![42; 10],
+        })
+        .unwrap();
+        buffer_account
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(buffer_address),
+            })
+            .unwrap();
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![(buffer_address, buffer_account.clone())],
+            instruction_accounts.clone(),
+            Err(InstructionError::AccountDataTooSmall),
+        );
+
+        // Case: overflow offset
+        let instruction = bincode::serialize(&UpgradeableLoaderInstruction::Write {
+            offset: 1,
+            bytes: vec![42; 9],
+        })
+        .unwrap();
+        buffer_account
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(buffer_address),
+            })
+            .unwrap();
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![(buffer_address, buffer_account.clone())],
+            instruction_accounts.clone(),
+            Err(InstructionError::AccountDataTooSmall),
+        );
+
+        // Case: Not signed
+        let instruction = bincode::serialize(&UpgradeableLoaderInstruction::Write {
+            offset: 0,
+            bytes: vec![42; 9],
+        })
+        .unwrap();
+        buffer_account
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(buffer_address),
+            })
+            .unwrap();
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![(buffer_address, buffer_account.clone())],
+            vec![
+                AccountMeta {
+                    pubkey: buffer_address,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: buffer_address,
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
+            Err(InstructionError::MissingRequiredSignature),
+        );
+
+        // Case: wrong authority
+        let authority_address = Pubkey::new_unique();
+        let instruction = bincode::serialize(&UpgradeableLoaderInstruction::Write {
+            offset: 1,
+            bytes: vec![42; 9],
+        })
+        .unwrap();
+        buffer_account
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(buffer_address),
+            })
+            .unwrap();
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (buffer_address, buffer_account.clone()),
+                (authority_address, buffer_account.clone()),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: buffer_address,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: authority_address,
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
+            Err(InstructionError::IncorrectAuthority),
+        );
+
+        // Case: None authority
+        let instruction = bincode::serialize(&UpgradeableLoaderInstruction::Write {
+            offset: 1,
+            bytes: vec![42; 9],
+        })
+        .unwrap();
+        buffer_account
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: None,
+            })
+            .unwrap();
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![(buffer_address, buffer_account.clone())],
+            instruction_accounts,
+            Err(InstructionError::Immutable),
+        );
+    }
+
+    fn truncate_data(account: &mut AccountSharedData, len: usize) {
+        let mut data = account.data().to_vec();
+        data.truncate(len);
+        account.set_data(data);
+    }
+
+    #[test]
+    fn test_bpf_loader_upgradeable_upgrade() {
+        let mut file = File::open("test_elfs/out/sbpfv3_return_ok.so").expect("file open failed");
+        let mut elf_orig = Vec::new();
+        file.read_to_end(&mut elf_orig).unwrap();
+        let mut file = File::open("test_elfs/out/sbpfv3_return_err.so").expect("file open failed");
+        let mut elf_new = Vec::new();
+        file.read_to_end(&mut elf_new).unwrap();
+        assert_ne!(elf_orig.len(), elf_new.len());
+        const SLOT: u64 = 42;
+        let buffer_address = Pubkey::new_unique();
+        let upgrade_authority_address = Pubkey::new_unique();
+
+        fn get_accounts(
+            buffer_address: &Pubkey,
+            buffer_authority: &Pubkey,
+            upgrade_authority_address: &Pubkey,
+            elf_orig: &[u8],
+            elf_new: &[u8],
+        ) -> (Vec<(Pubkey, AccountSharedData)>, Vec<AccountMeta>) {
+            let loader_id = bpf_loader_upgradeable::id();
+            let program_address = Pubkey::new_unique();
+            let spill_address = Pubkey::new_unique();
+            let rent = Rent::default();
+            let min_program_balance =
+                1.max(rent.minimum_balance(UpgradeableLoaderState::size_of_program()));
+            let min_programdata_balance = 1.max(rent.minimum_balance(
+                UpgradeableLoaderState::size_of_programdata(elf_orig.len().max(elf_new.len())),
+            ));
+            let (programdata_address, _) =
+                Pubkey::find_program_address(&[program_address.as_ref()], &loader_id);
+            let mut buffer_account = AccountSharedData::new(
+                1,
+                UpgradeableLoaderState::size_of_buffer(elf_new.len()),
+                &bpf_loader_upgradeable::id(),
+            );
+            buffer_account
+                .set_state(&UpgradeableLoaderState::Buffer {
+                    authority_address: Some(*buffer_authority),
+                })
+                .unwrap();
+            buffer_account
+                .data_as_mut_slice()
+                .get_mut(UpgradeableLoaderState::size_of_buffer_metadata()..)
+                .unwrap()
+                .copy_from_slice(elf_new);
+            let mut programdata_account = AccountSharedData::new(
+                min_programdata_balance,
+                UpgradeableLoaderState::size_of_programdata(elf_orig.len().max(elf_new.len())),
+                &bpf_loader_upgradeable::id(),
+            );
+            programdata_account
+                .set_state(&UpgradeableLoaderState::ProgramData {
+                    slot: SLOT,
+                    upgrade_authority_address: Some(*upgrade_authority_address),
+                })
+                .unwrap();
+            let mut program_account = AccountSharedData::new(
+                min_program_balance,
+                UpgradeableLoaderState::size_of_program(),
+                &bpf_loader_upgradeable::id(),
+            );
+            program_account.set_executable(true);
+            program_account
+                .set_state(&UpgradeableLoaderState::Program {
+                    programdata_address,
+                })
+                .unwrap();
+            let spill_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
+            let rent_account = create_account_for_test(&rent);
+            let clock_account = create_account_for_test(&Clock {
+                slot: SLOT.saturating_add(1),
+                ..Clock::default()
+            });
+            let upgrade_authority_account = AccountSharedData::new(1, 0, &Pubkey::new_unique());
+            let transaction_accounts = vec![
+                (programdata_address, programdata_account),
+                (program_address, program_account),
+                (*buffer_address, buffer_account),
+                (spill_address, spill_account),
+                (sysvar::rent::id(), rent_account),
+                (sysvar::clock::id(), clock_account),
+                (*upgrade_authority_address, upgrade_authority_account),
+            ];
+            let instruction_accounts = vec![
+                AccountMeta {
+                    pubkey: programdata_address,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: program_address,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: *buffer_address,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: spill_address,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: sysvar::rent::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: sysvar::clock::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: *upgrade_authority_address,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ];
+            (transaction_accounts, instruction_accounts)
+        }
+
+        fn process_instruction(
+            transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+            instruction_accounts: Vec<AccountMeta>,
+            expected_result: Result<(), InstructionError>,
+        ) -> Vec<AccountSharedData> {
+            let instruction_data =
+                bincode::serialize(&UpgradeableLoaderInstruction::Upgrade).unwrap();
+            mock_process_instruction(
+                &bpf_loader_upgradeable::id(),
+                None,
+                &instruction_data,
+                transaction_accounts,
+                instruction_accounts,
+                expected_result,
+                Entrypoint::vm,
+                |_invoke_context| {},
+                |_invoke_context| {},
+            )
+        }
+
+        // Case: Success
+        let (transaction_accounts, instruction_accounts) = get_accounts(
+            &buffer_address,
+            &upgrade_authority_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        let accounts = process_instruction(transaction_accounts, instruction_accounts, Ok(()));
+        let min_programdata_balance = Rent::default().minimum_balance(
+            UpgradeableLoaderState::size_of_programdata(elf_orig.len().max(elf_new.len())),
+        );
+        assert_eq!(
+            min_programdata_balance,
+            accounts.first().unwrap().lamports()
+        );
+        assert_eq!(0, accounts.get(2).unwrap().lamports());
+        assert_eq!(1, accounts.get(3).unwrap().lamports());
+        let state: UpgradeableLoaderState = accounts.first().unwrap().state().unwrap();
+        assert_eq!(
+            state,
+            UpgradeableLoaderState::ProgramData {
+                slot: SLOT.saturating_add(1),
+                upgrade_authority_address: Some(upgrade_authority_address)
+            }
+        );
+        for (i, byte) in accounts
+            .first()
+            .unwrap()
+            .data()
+            .get(
+                UpgradeableLoaderState::size_of_programdata_metadata()
+                    ..UpgradeableLoaderState::size_of_programdata(elf_new.len()),
+            )
+            .unwrap()
+            .iter()
+            .enumerate()
+        {
+            assert_eq!(*elf_new.get(i).unwrap(), *byte);
+        }
+
+        // Case: not upgradable
+        let (mut transaction_accounts, instruction_accounts) = get_accounts(
+            &buffer_address,
+            &upgrade_authority_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        transaction_accounts
+            .get_mut(0)
+            .unwrap()
+            .1
+            .set_state(&UpgradeableLoaderState::ProgramData {
+                slot: SLOT,
+                upgrade_authority_address: None,
+            })
+            .unwrap();
+        process_instruction(
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::Immutable),
+        );
+
+        // Case: wrong authority
+        let (mut transaction_accounts, mut instruction_accounts) = get_accounts(
+            &buffer_address,
+            &upgrade_authority_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        let invalid_upgrade_authority_address = Pubkey::new_unique();
+        transaction_accounts.get_mut(6).unwrap().0 = invalid_upgrade_authority_address;
+        instruction_accounts.get_mut(6).unwrap().pubkey = invalid_upgrade_authority_address;
+        process_instruction(
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::IncorrectAuthority),
+        );
+
+        // Case: authority did not sign
+        let (transaction_accounts, mut instruction_accounts) = get_accounts(
+            &buffer_address,
+            &upgrade_authority_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        instruction_accounts.get_mut(6).unwrap().is_signer = false;
+        process_instruction(
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::MissingRequiredSignature),
+        );
+
+        // Case: Buffer account and spill account alias
+        let (transaction_accounts, mut instruction_accounts) = get_accounts(
+            &buffer_address,
+            &upgrade_authority_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        *instruction_accounts.get_mut(3).unwrap() = instruction_accounts.get(2).unwrap().clone();
+        process_instruction(
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::AccountBorrowFailed),
+        );
+
+        // Case: Programdata account and spill account alias
+        let (transaction_accounts, mut instruction_accounts) = get_accounts(
+            &buffer_address,
+            &upgrade_authority_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        *instruction_accounts.get_mut(3).unwrap() = instruction_accounts.first().unwrap().clone();
+        process_instruction(
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::AccountBorrowFailed),
+        );
+
+        // Case: Program account not a program
+        let (transaction_accounts, mut instruction_accounts) = get_accounts(
+            &buffer_address,
+            &upgrade_authority_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        *instruction_accounts.get_mut(1).unwrap() = instruction_accounts.get(2).unwrap().clone();
+        let instruction_data = bincode::serialize(&UpgradeableLoaderInstruction::Upgrade).unwrap();
+
+        mock_process_instruction(
+            &bpf_loader_upgradeable::id(),
+            None,
+            &instruction_data,
+            transaction_accounts.clone(),
+            instruction_accounts.clone(),
+            Err(InstructionError::InvalidAccountData),
+            Entrypoint::vm,
+            |invoke_context| {
+                test_utils::load_all_invoked_programs(invoke_context);
+            },
+            |_invoke_context| {},
+        );
+        process_instruction(
+            transaction_accounts.clone(),
+            instruction_accounts.clone(),
+            Err(InstructionError::InvalidAccountData),
+        );
+
+        // Case: Program account now owned by loader
+        let (mut transaction_accounts, instruction_accounts) = get_accounts(
+            &buffer_address,
+            &upgrade_authority_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        transaction_accounts
+            .get_mut(1)
+            .unwrap()
+            .1
+            .set_owner(Pubkey::new_unique());
+        process_instruction(
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::IncorrectProgramId),
+        );
+
+        // Case: Program account not writable
+        let (transaction_accounts, mut instruction_accounts) = get_accounts(
+            &buffer_address,
+            &upgrade_authority_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        instruction_accounts.get_mut(1).unwrap().is_writable = false;
+        process_instruction(
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::InvalidArgument),
+        );
+
+        // Case: Program account not initialized
+        let (mut transaction_accounts, instruction_accounts) = get_accounts(
+            &buffer_address,
+            &upgrade_authority_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        transaction_accounts
+            .get_mut(1)
+            .unwrap()
+            .1
+            .set_state(&UpgradeableLoaderState::Uninitialized)
+            .unwrap();
+        process_instruction(
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::InvalidAccountData),
+        );
+
+        // Case: Program ProgramData account mismatch
+        let (mut transaction_accounts, mut instruction_accounts) = get_accounts(
+            &buffer_address,
+            &upgrade_authority_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        let invalid_programdata_address = Pubkey::new_unique();
+        transaction_accounts.get_mut(0).unwrap().0 = invalid_programdata_address;
+        instruction_accounts.get_mut(0).unwrap().pubkey = invalid_programdata_address;
+        process_instruction(
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::InvalidArgument),
+        );
+
+        // Case: Buffer account not initialized
+        let (mut transaction_accounts, instruction_accounts) = get_accounts(
+            &buffer_address,
+            &upgrade_authority_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        transaction_accounts
+            .get_mut(2)
+            .unwrap()
+            .1
+            .set_state(&UpgradeableLoaderState::Uninitialized)
+            .unwrap();
+        process_instruction(
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::InvalidArgument),
+        );
+
+        // Case: Buffer account too big
+        let (mut transaction_accounts, instruction_accounts) = get_accounts(
+            &buffer_address,
+            &upgrade_authority_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        transaction_accounts.get_mut(2).unwrap().1 = AccountSharedData::new(
+            1,
+            UpgradeableLoaderState::size_of_buffer(
+                elf_orig.len().max(elf_new.len()).saturating_add(1),
+            ),
+            &bpf_loader_upgradeable::id(),
+        );
+        transaction_accounts
+            .get_mut(2)
+            .unwrap()
+            .1
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(upgrade_authority_address),
+            })
+            .unwrap();
+        process_instruction(
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::AccountDataTooSmall),
+        );
+
+        // Case: Buffer account too small
+        let (mut transaction_accounts, instruction_accounts) = get_accounts(
+            &buffer_address,
+            &upgrade_authority_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        transaction_accounts
+            .get_mut(2)
+            .unwrap()
+            .1
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(upgrade_authority_address),
+            })
+            .unwrap();
+        truncate_data(&mut transaction_accounts.get_mut(2).unwrap().1, 5);
+        process_instruction(
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::InvalidAccountData),
+        );
+
+        // Case: Mismatched buffer and program authority
+        let (transaction_accounts, instruction_accounts) = get_accounts(
+            &buffer_address,
+            &buffer_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        process_instruction(
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::IncorrectAuthority),
+        );
+
+        // Case: No buffer authority
+        let (mut transaction_accounts, instruction_accounts) = get_accounts(
+            &buffer_address,
+            &buffer_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        transaction_accounts
+            .get_mut(2)
+            .unwrap()
+            .1
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: None,
+            })
+            .unwrap();
+        process_instruction(
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::IncorrectAuthority),
+        );
+
+        // Case: No buffer and program authority
+        let (mut transaction_accounts, instruction_accounts) = get_accounts(
+            &buffer_address,
+            &buffer_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        transaction_accounts
+            .get_mut(0)
+            .unwrap()
+            .1
+            .set_state(&UpgradeableLoaderState::ProgramData {
+                slot: SLOT,
+                upgrade_authority_address: None,
+            })
+            .unwrap();
+        transaction_accounts
+            .get_mut(2)
+            .unwrap()
+            .1
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: None,
+            })
+            .unwrap();
+        process_instruction(
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::IncorrectAuthority),
+        );
+    }
+
+    #[test]
+    fn test_bpf_loader_upgradeable_set_upgrade_authority() {
+        let instruction = bincode::serialize(&UpgradeableLoaderInstruction::SetAuthority).unwrap();
+        let loader_id = bpf_loader_upgradeable::id();
+        let slot = 0;
+        let upgrade_authority_address = Pubkey::new_unique();
+        let upgrade_authority_account = AccountSharedData::new(1, 0, &Pubkey::new_unique());
+        let new_upgrade_authority_address = Pubkey::new_unique();
+        let new_upgrade_authority_account = AccountSharedData::new(1, 0, &Pubkey::new_unique());
+        let program_address = Pubkey::new_unique();
+        let (programdata_address, _) = Pubkey::find_program_address(
+            &[program_address.as_ref()],
+            &bpf_loader_upgradeable::id(),
+        );
+        let mut programdata_account = AccountSharedData::new(
+            1,
+            UpgradeableLoaderState::size_of_programdata(0),
+            &bpf_loader_upgradeable::id(),
+        );
+        programdata_account
+            .set_state(&UpgradeableLoaderState::ProgramData {
+                slot,
+                upgrade_authority_address: Some(upgrade_authority_address),
+            })
+            .unwrap();
+        let programdata_meta = AccountMeta {
+            pubkey: programdata_address,
+            is_signer: false,
+            is_writable: true,
+        };
+        let upgrade_authority_meta = AccountMeta {
+            pubkey: upgrade_authority_address,
+            is_signer: true,
+            is_writable: false,
+        };
+        let new_upgrade_authority_meta = AccountMeta {
+            pubkey: new_upgrade_authority_address,
+            is_signer: false,
+            is_writable: false,
+        };
+
+        // Case: Set to new authority
+        let accounts = process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (upgrade_authority_address, upgrade_authority_account.clone()),
+                (
+                    new_upgrade_authority_address,
+                    new_upgrade_authority_account.clone(),
+                ),
+            ],
+            vec![
+                programdata_meta.clone(),
+                upgrade_authority_meta.clone(),
+                new_upgrade_authority_meta.clone(),
+            ],
+            Ok(()),
+        );
+        let state: UpgradeableLoaderState = accounts.first().unwrap().state().unwrap();
+        assert_eq!(
+            state,
+            UpgradeableLoaderState::ProgramData {
+                slot,
+                upgrade_authority_address: Some(new_upgrade_authority_address),
+            }
+        );
+
+        // Case: Not upgradeable
+        let accounts = process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (upgrade_authority_address, upgrade_authority_account.clone()),
+            ],
+            vec![programdata_meta.clone(), upgrade_authority_meta.clone()],
+            Ok(()),
+        );
+        let state: UpgradeableLoaderState = accounts.first().unwrap().state().unwrap();
+        assert_eq!(
+            state,
+            UpgradeableLoaderState::ProgramData {
+                slot,
+                upgrade_authority_address: None,
+            }
+        );
+
+        // Case: Authority did not sign
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (upgrade_authority_address, upgrade_authority_account.clone()),
+            ],
+            vec![
+                programdata_meta.clone(),
+                AccountMeta {
+                    pubkey: upgrade_authority_address,
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
+            Err(InstructionError::MissingRequiredSignature),
+        );
+
+        // Case: wrong authority
+        let invalid_upgrade_authority_address = Pubkey::new_unique();
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (
+                    invalid_upgrade_authority_address,
+                    upgrade_authority_account.clone(),
+                ),
+                (new_upgrade_authority_address, new_upgrade_authority_account),
+            ],
+            vec![
+                programdata_meta.clone(),
+                AccountMeta {
+                    pubkey: invalid_upgrade_authority_address,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                new_upgrade_authority_meta,
+            ],
+            Err(InstructionError::IncorrectAuthority),
+        );
+
+        // Case: No authority
+        programdata_account
+            .set_state(&UpgradeableLoaderState::ProgramData {
+                slot,
+                upgrade_authority_address: None,
+            })
+            .unwrap();
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (upgrade_authority_address, upgrade_authority_account.clone()),
+            ],
+            vec![programdata_meta.clone(), upgrade_authority_meta.clone()],
+            Err(InstructionError::Immutable),
+        );
+
+        // Case: Not a ProgramData account
+        programdata_account
+            .set_state(&UpgradeableLoaderState::Program {
+                programdata_address: Pubkey::new_unique(),
+            })
+            .unwrap();
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (upgrade_authority_address, upgrade_authority_account),
+            ],
+            vec![programdata_meta, upgrade_authority_meta],
+            Err(InstructionError::InvalidArgument),
+        );
+    }
+
+    #[test]
+    fn test_bpf_loader_upgradeable_set_upgrade_authority_checked() {
+        let instruction =
+            bincode::serialize(&UpgradeableLoaderInstruction::SetAuthorityChecked).unwrap();
+        let loader_id = bpf_loader_upgradeable::id();
+        let slot = 0;
+        let upgrade_authority_address = Pubkey::new_unique();
+        let upgrade_authority_account = AccountSharedData::new(1, 0, &Pubkey::new_unique());
+        let new_upgrade_authority_address = Pubkey::new_unique();
+        let new_upgrade_authority_account = AccountSharedData::new(1, 0, &Pubkey::new_unique());
+        let program_address = Pubkey::new_unique();
+        let (programdata_address, _) = Pubkey::find_program_address(
+            &[program_address.as_ref()],
+            &bpf_loader_upgradeable::id(),
+        );
+        let mut programdata_account = AccountSharedData::new(
+            1,
+            UpgradeableLoaderState::size_of_programdata(0),
+            &bpf_loader_upgradeable::id(),
+        );
+        programdata_account
+            .set_state(&UpgradeableLoaderState::ProgramData {
+                slot,
+                upgrade_authority_address: Some(upgrade_authority_address),
+            })
+            .unwrap();
+        let programdata_meta = AccountMeta {
+            pubkey: programdata_address,
+            is_signer: false,
+            is_writable: true,
+        };
+        let upgrade_authority_meta = AccountMeta {
+            pubkey: upgrade_authority_address,
+            is_signer: true,
+            is_writable: false,
+        };
+        let new_upgrade_authority_meta = AccountMeta {
+            pubkey: new_upgrade_authority_address,
+            is_signer: true,
+            is_writable: false,
+        };
+
+        // Case: Set to new authority
+        let accounts = process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (upgrade_authority_address, upgrade_authority_account.clone()),
+                (
+                    new_upgrade_authority_address,
+                    new_upgrade_authority_account.clone(),
+                ),
+            ],
+            vec![
+                programdata_meta.clone(),
+                upgrade_authority_meta.clone(),
+                new_upgrade_authority_meta.clone(),
+            ],
+            Ok(()),
+        );
+
+        let state: UpgradeableLoaderState = accounts.first().unwrap().state().unwrap();
+        assert_eq!(
+            state,
+            UpgradeableLoaderState::ProgramData {
+                slot,
+                upgrade_authority_address: Some(new_upgrade_authority_address),
+            }
+        );
+
+        // Case: set to same authority
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (upgrade_authority_address, upgrade_authority_account.clone()),
+            ],
+            vec![
+                programdata_meta.clone(),
+                upgrade_authority_meta.clone(),
+                upgrade_authority_meta.clone(),
+            ],
+            Ok(()),
+        );
+
+        // Case: present authority not in instruction
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (upgrade_authority_address, upgrade_authority_account.clone()),
+                (
+                    new_upgrade_authority_address,
+                    new_upgrade_authority_account.clone(),
+                ),
+            ],
+            vec![programdata_meta.clone(), new_upgrade_authority_meta.clone()],
+            Err(InstructionError::MissingAccount),
+        );
+
+        // Case: new authority not in instruction
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (upgrade_authority_address, upgrade_authority_account.clone()),
+                (
+                    new_upgrade_authority_address,
+                    new_upgrade_authority_account.clone(),
+                ),
+            ],
+            vec![programdata_meta.clone(), upgrade_authority_meta.clone()],
+            Err(InstructionError::MissingAccount),
+        );
+
+        // Case: present authority did not sign
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (upgrade_authority_address, upgrade_authority_account.clone()),
+                (
+                    new_upgrade_authority_address,
+                    new_upgrade_authority_account.clone(),
+                ),
+            ],
+            vec![
+                programdata_meta.clone(),
+                AccountMeta {
+                    pubkey: upgrade_authority_address,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                new_upgrade_authority_meta.clone(),
+            ],
+            Err(InstructionError::MissingRequiredSignature),
+        );
+
+        // Case: New authority did not sign
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (upgrade_authority_address, upgrade_authority_account.clone()),
+                (
+                    new_upgrade_authority_address,
+                    new_upgrade_authority_account.clone(),
+                ),
+            ],
+            vec![
+                programdata_meta.clone(),
+                upgrade_authority_meta.clone(),
+                AccountMeta {
+                    pubkey: new_upgrade_authority_address,
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
+            Err(InstructionError::MissingRequiredSignature),
+        );
+
+        // Case: wrong present authority
+        let invalid_upgrade_authority_address = Pubkey::new_unique();
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (
+                    invalid_upgrade_authority_address,
+                    upgrade_authority_account.clone(),
+                ),
+                (new_upgrade_authority_address, new_upgrade_authority_account),
+            ],
+            vec![
+                programdata_meta.clone(),
+                AccountMeta {
+                    pubkey: invalid_upgrade_authority_address,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                new_upgrade_authority_meta.clone(),
+            ],
+            Err(InstructionError::IncorrectAuthority),
+        );
+
+        // Case: programdata is immutable
+        programdata_account
+            .set_state(&UpgradeableLoaderState::ProgramData {
+                slot,
+                upgrade_authority_address: None,
+            })
+            .unwrap();
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (upgrade_authority_address, upgrade_authority_account.clone()),
+            ],
+            vec![
+                programdata_meta.clone(),
+                upgrade_authority_meta.clone(),
+                new_upgrade_authority_meta.clone(),
+            ],
+            Err(InstructionError::Immutable),
+        );
+
+        // Case: Not a ProgramData account
+        programdata_account
+            .set_state(&UpgradeableLoaderState::Program {
+                programdata_address: Pubkey::new_unique(),
+            })
+            .unwrap();
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (upgrade_authority_address, upgrade_authority_account),
+            ],
+            vec![
+                programdata_meta,
+                upgrade_authority_meta,
+                new_upgrade_authority_meta,
+            ],
+            Err(InstructionError::InvalidArgument),
+        );
+    }
+
+    #[test]
+    fn test_bpf_loader_upgradeable_set_buffer_authority() {
+        let instruction = bincode::serialize(&UpgradeableLoaderInstruction::SetAuthority).unwrap();
+        let loader_id = bpf_loader_upgradeable::id();
+        let invalid_authority_address = Pubkey::new_unique();
+        let authority_address = Pubkey::new_unique();
+        let authority_account = AccountSharedData::new(1, 0, &Pubkey::new_unique());
+        let new_authority_address = Pubkey::new_unique();
+        let new_authority_account = AccountSharedData::new(1, 0, &Pubkey::new_unique());
+        let buffer_address = Pubkey::new_unique();
+        let mut buffer_account =
+            AccountSharedData::new(1, UpgradeableLoaderState::size_of_buffer(0), &loader_id);
+        buffer_account
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(authority_address),
+            })
+            .unwrap();
+        let mut transaction_accounts = vec![
+            (buffer_address, buffer_account.clone()),
+            (authority_address, authority_account.clone()),
+            (new_authority_address, new_authority_account.clone()),
+        ];
+        let buffer_meta = AccountMeta {
+            pubkey: buffer_address,
+            is_signer: false,
+            is_writable: true,
+        };
+        let authority_meta = AccountMeta {
+            pubkey: authority_address,
+            is_signer: true,
+            is_writable: false,
+        };
+        let new_authority_meta = AccountMeta {
+            pubkey: new_authority_address,
+            is_signer: false,
+            is_writable: false,
+        };
+
+        // Case: New authority required
+        let accounts = process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            vec![buffer_meta.clone(), authority_meta.clone()],
+            Err(InstructionError::IncorrectAuthority),
+        );
+        let state: UpgradeableLoaderState = accounts.first().unwrap().state().unwrap();
+        assert_eq!(
+            state,
+            UpgradeableLoaderState::Buffer {
+                authority_address: Some(authority_address),
+            }
+        );
+
+        // Case: Set to new authority
+        buffer_account
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(authority_address),
+            })
+            .unwrap();
+        let accounts = process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            vec![
+                buffer_meta.clone(),
+                authority_meta.clone(),
+                new_authority_meta.clone(),
+            ],
+            Ok(()),
+        );
+        let state: UpgradeableLoaderState = accounts.first().unwrap().state().unwrap();
+        assert_eq!(
+            state,
+            UpgradeableLoaderState::Buffer {
+                authority_address: Some(new_authority_address),
+            }
+        );
+
+        // Case: Authority did not sign
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            vec![
+                buffer_meta.clone(),
+                AccountMeta {
+                    pubkey: authority_address,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                new_authority_meta.clone(),
+            ],
+            Err(InstructionError::MissingRequiredSignature),
+        );
+
+        // Case: wrong authority
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (buffer_address, buffer_account.clone()),
+                (invalid_authority_address, authority_account),
+                (new_authority_address, new_authority_account),
+            ],
+            vec![
+                buffer_meta.clone(),
+                AccountMeta {
+                    pubkey: invalid_authority_address,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                new_authority_meta.clone(),
+            ],
+            Err(InstructionError::IncorrectAuthority),
+        );
+
+        // Case: No authority
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            vec![buffer_meta.clone(), authority_meta.clone()],
+            Err(InstructionError::IncorrectAuthority),
+        );
+
+        // Case: Set to no authority
+        transaction_accounts
+            .get_mut(0)
+            .unwrap()
+            .1
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: None,
+            })
+            .unwrap();
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            vec![
+                buffer_meta.clone(),
+                authority_meta.clone(),
+                new_authority_meta.clone(),
+            ],
+            Err(InstructionError::Immutable),
+        );
+
+        // Case: Not a Buffer account
+        transaction_accounts
+            .get_mut(0)
+            .unwrap()
+            .1
+            .set_state(&UpgradeableLoaderState::Program {
+                programdata_address: Pubkey::new_unique(),
+            })
+            .unwrap();
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            vec![buffer_meta, authority_meta, new_authority_meta],
+            Err(InstructionError::InvalidArgument),
+        );
+    }
+
+    #[test]
+    fn test_bpf_loader_upgradeable_set_buffer_authority_checked() {
+        let instruction =
+            bincode::serialize(&UpgradeableLoaderInstruction::SetAuthorityChecked).unwrap();
+        let loader_id = bpf_loader_upgradeable::id();
+        let invalid_authority_address = Pubkey::new_unique();
+        let authority_address = Pubkey::new_unique();
+        let authority_account = AccountSharedData::new(1, 0, &Pubkey::new_unique());
+        let new_authority_address = Pubkey::new_unique();
+        let new_authority_account = AccountSharedData::new(1, 0, &Pubkey::new_unique());
+        let buffer_address = Pubkey::new_unique();
+        let mut buffer_account =
+            AccountSharedData::new(1, UpgradeableLoaderState::size_of_buffer(0), &loader_id);
+        buffer_account
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(authority_address),
+            })
+            .unwrap();
+        let mut transaction_accounts = vec![
+            (buffer_address, buffer_account.clone()),
+            (authority_address, authority_account.clone()),
+            (new_authority_address, new_authority_account.clone()),
+        ];
+        let buffer_meta = AccountMeta {
+            pubkey: buffer_address,
+            is_signer: false,
+            is_writable: true,
+        };
+        let authority_meta = AccountMeta {
+            pubkey: authority_address,
+            is_signer: true,
+            is_writable: false,
+        };
+        let new_authority_meta = AccountMeta {
+            pubkey: new_authority_address,
+            is_signer: true,
+            is_writable: false,
+        };
+
+        // Case: Set to new authority
+        buffer_account
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(authority_address),
+            })
+            .unwrap();
+        let accounts = process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            vec![
+                buffer_meta.clone(),
+                authority_meta.clone(),
+                new_authority_meta.clone(),
+            ],
+            Ok(()),
+        );
+        let state: UpgradeableLoaderState = accounts.first().unwrap().state().unwrap();
+        assert_eq!(
+            state,
+            UpgradeableLoaderState::Buffer {
+                authority_address: Some(new_authority_address),
+            }
+        );
+
+        // Case: set to same authority
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            vec![
+                buffer_meta.clone(),
+                authority_meta.clone(),
+                authority_meta.clone(),
+            ],
+            Ok(()),
+        );
+
+        // Case: Missing current authority
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            vec![buffer_meta.clone(), new_authority_meta.clone()],
+            Err(InstructionError::MissingAccount),
+        );
+
+        // Case: Missing new authority
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            vec![buffer_meta.clone(), authority_meta.clone()],
+            Err(InstructionError::MissingAccount),
+        );
+
+        // Case: wrong present authority
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (buffer_address, buffer_account.clone()),
+                (invalid_authority_address, authority_account),
+                (new_authority_address, new_authority_account),
+            ],
+            vec![
+                buffer_meta.clone(),
+                AccountMeta {
+                    pubkey: invalid_authority_address,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                new_authority_meta.clone(),
+            ],
+            Err(InstructionError::IncorrectAuthority),
+        );
+
+        // Case: present authority did not sign
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            vec![
+                buffer_meta.clone(),
+                AccountMeta {
+                    pubkey: authority_address,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                new_authority_meta.clone(),
+            ],
+            Err(InstructionError::MissingRequiredSignature),
+        );
+
+        // Case: new authority did not sign
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            vec![
+                buffer_meta.clone(),
+                authority_meta.clone(),
+                AccountMeta {
+                    pubkey: new_authority_address,
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
+            Err(InstructionError::MissingRequiredSignature),
+        );
+
+        // Case: Not a Buffer account
+        transaction_accounts
+            .get_mut(0)
+            .unwrap()
+            .1
+            .set_state(&UpgradeableLoaderState::Program {
+                programdata_address: Pubkey::new_unique(),
+            })
+            .unwrap();
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            vec![
+                buffer_meta.clone(),
+                authority_meta.clone(),
+                new_authority_meta.clone(),
+            ],
+            Err(InstructionError::InvalidArgument),
+        );
+
+        // Case: Buffer is immutable
+        transaction_accounts
+            .get_mut(0)
+            .unwrap()
+            .1
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: None,
+            })
+            .unwrap();
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            vec![buffer_meta, authority_meta, new_authority_meta],
+            Err(InstructionError::Immutable),
+        );
+    }
+
+    #[test]
+    fn test_bpf_loader_upgradeable_close() {
+        let instruction = bincode::serialize(&UpgradeableLoaderInstruction::Close).unwrap();
+        let loader_id = bpf_loader_upgradeable::id();
+        let invalid_authority_address = Pubkey::new_unique();
+        let authority_address = Pubkey::new_unique();
+        let authority_account = AccountSharedData::new(1, 0, &Pubkey::new_unique());
+        let recipient_address = Pubkey::new_unique();
+        let recipient_account = AccountSharedData::new(1, 0, &Pubkey::new_unique());
+        let buffer_address = Pubkey::new_unique();
+        let mut buffer_account =
+            AccountSharedData::new(1, UpgradeableLoaderState::size_of_buffer(128), &loader_id);
+        buffer_account
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(authority_address),
+            })
+            .unwrap();
+        let uninitialized_address = Pubkey::new_unique();
+        let mut uninitialized_account = AccountSharedData::new(
+            1,
+            UpgradeableLoaderState::size_of_programdata(0),
+            &loader_id,
+        );
+        uninitialized_account
+            .set_state(&UpgradeableLoaderState::Uninitialized)
+            .unwrap();
+        let programdata_address = Pubkey::new_unique();
+        let mut programdata_account = AccountSharedData::new(
+            1,
+            UpgradeableLoaderState::size_of_programdata(128),
+            &loader_id,
+        );
+        programdata_account
+            .set_state(&UpgradeableLoaderState::ProgramData {
+                slot: 0,
+                upgrade_authority_address: Some(authority_address),
+            })
+            .unwrap();
+        let program_address = Pubkey::new_unique();
+        let mut program_account =
+            AccountSharedData::new(1, UpgradeableLoaderState::size_of_program(), &loader_id);
+        program_account.set_executable(true);
+        program_account
+            .set_state(&UpgradeableLoaderState::Program {
+                programdata_address,
+            })
+            .unwrap();
+        let clock_account = create_account_for_test(&Clock {
+            slot: 1,
+            ..Clock::default()
+        });
+        let transaction_accounts = vec![
+            (buffer_address, buffer_account.clone()),
+            (recipient_address, recipient_account.clone()),
+            (authority_address, authority_account.clone()),
+        ];
+        let buffer_meta = AccountMeta {
+            pubkey: buffer_address,
+            is_signer: false,
+            is_writable: true,
+        };
+        let recipient_meta = AccountMeta {
+            pubkey: recipient_address,
+            is_signer: false,
+            is_writable: true,
+        };
+        let authority_meta = AccountMeta {
+            pubkey: authority_address,
+            is_signer: true,
+            is_writable: false,
+        };
+
+        // Case: close a buffer account
+        let accounts = process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            transaction_accounts,
+            vec![
+                buffer_meta.clone(),
+                recipient_meta.clone(),
+                authority_meta.clone(),
+            ],
+            Ok(()),
+        );
+        assert_eq!(0, accounts.first().unwrap().lamports());
+        assert_eq!(2, accounts.get(1).unwrap().lamports());
+        let state: UpgradeableLoaderState = accounts.first().unwrap().state().unwrap();
+        assert_eq!(state, UpgradeableLoaderState::Uninitialized);
+        assert_eq!(
+            UpgradeableLoaderState::size_of_uninitialized(),
+            accounts.first().unwrap().data().len()
+        );
+
+        // Case: close with wrong authority
+        process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (buffer_address, buffer_account.clone()),
+                (recipient_address, recipient_account.clone()),
+                (invalid_authority_address, authority_account.clone()),
+            ],
+            vec![
+                buffer_meta,
+                recipient_meta.clone(),
+                AccountMeta {
+                    pubkey: invalid_authority_address,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ],
+            Err(InstructionError::IncorrectAuthority),
+        );
+
+        // Case: close an uninitialized account
+        let accounts = process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (uninitialized_address, uninitialized_account.clone()),
+                (recipient_address, recipient_account.clone()),
+                (invalid_authority_address, authority_account.clone()),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: uninitialized_address,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                recipient_meta.clone(),
+                authority_meta.clone(),
+            ],
+            Ok(()),
+        );
+        assert_eq!(0, accounts.first().unwrap().lamports());
+        assert_eq!(2, accounts.get(1).unwrap().lamports());
+        let state: UpgradeableLoaderState = accounts.first().unwrap().state().unwrap();
+        assert_eq!(state, UpgradeableLoaderState::Uninitialized);
+        assert_eq!(
+            UpgradeableLoaderState::size_of_uninitialized(),
+            accounts.first().unwrap().data().len()
+        );
+
+        // Case: close a program account
+        let accounts = process_instruction(
+            &loader_id,
+            None,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (recipient_address, recipient_account.clone()),
+                (authority_address, authority_account.clone()),
+                (program_address, program_account.clone()),
+                (sysvar::clock::id(), clock_account.clone()),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: programdata_address,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                recipient_meta,
+                authority_meta,
+                AccountMeta {
+                    pubkey: program_address,
+                    is_signer: false,
+                    is_writable: true,
+                },
+            ],
+            Ok(()),
+        );
+        assert_eq!(0, accounts.first().unwrap().lamports());
+        assert_eq!(2, accounts.get(1).unwrap().lamports());
+        let state: UpgradeableLoaderState = accounts.first().unwrap().state().unwrap();
+        assert_eq!(state, UpgradeableLoaderState::Uninitialized);
+        assert_eq!(
+            UpgradeableLoaderState::size_of_uninitialized(),
+            accounts.first().unwrap().data().len()
+        );
+
+        // Try to invoke closed account
+        programdata_account = accounts.first().unwrap().clone();
+        program_account = accounts.get(3).unwrap().clone();
+        process_instruction(
+            &loader_id,
+            Some(1),
+            &[],
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (program_address, program_account.clone()),
+            ],
+            Vec::new(),
+            Err(InstructionError::UnsupportedProgramId),
+        );
+
+        // Case: Reopen should fail
+        process_instruction(
+            &loader_id,
+            None,
+            &bincode::serialize(&UpgradeableLoaderInstruction::DeployWithMaxDataLen {
+                max_data_len: 0,
+            })
+            .unwrap(),
+            vec![
+                (recipient_address, recipient_account),
+                (programdata_address, programdata_account),
+                (program_address, program_account),
+                (buffer_address, buffer_account),
+                (
+                    sysvar::rent::id(),
+                    create_account_for_test(&Rent::default()),
+                ),
+                (sysvar::clock::id(), clock_account),
+                (
+                    system_program::id(),
+                    AccountSharedData::new(0, 0, &system_program::id()),
+                ),
+                (authority_address, authority_account),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: recipient_address,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: programdata_address,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: program_address,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: buffer_address,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: sysvar::rent::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: sysvar::clock::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: system_program::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: authority_address,
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
+            Err(InstructionError::AccountAlreadyInitialized),
+        );
+    }
+
+    /// fuzzing utility function
+    fn fuzz<F>(
+        bytes: &[u8],
+        outer_iters: usize,
+        inner_iters: usize,
+        offset: Range<usize>,
+        value: Range<u8>,
+        work: F,
+    ) where
+        F: Fn(&mut [u8]),
+    {
+        let mut rng = rand::thread_rng();
+        for _ in 0..outer_iters {
+            let mut mangled_bytes = bytes.to_vec();
+            for _ in 0..inner_iters {
+                let offset = rng.gen_range(offset.start..offset.end);
+                let value = rng.gen_range(value.start..value.end);
+                *mangled_bytes.get_mut(offset).unwrap() = value;
+                work(&mut mangled_bytes);
+            }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn test_fuzz() {
+        let loader_id = bpf_loader::id();
+        let program_id = Pubkey::new_unique();
+
+        // Create program account
+        let mut file = File::open("test_elfs/out/sbpfv3_return_ok.so").expect("file open failed");
+        let mut elf = Vec::new();
+        file.read_to_end(&mut elf).unwrap();
+
+        // Mangle the whole file
+        fuzz(
+            &elf,
+            1_000_000_000,
+            100,
+            0..elf.len(),
+            0..255,
+            |bytes: &mut [u8]| {
+                let mut program_account = AccountSharedData::new(1, 0, &loader_id);
+                program_account.set_data(bytes.to_vec());
+                program_account.set_executable(true);
+                process_instruction(
+                    &loader_id,
+                    None,
+                    &[],
+                    vec![(program_id, program_account)],
+                    Vec::new(),
+                    Ok(()),
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_calculate_heap_cost() {
+        let heap_cost = 8_u64;
+
+        // heap allocations are in 32K block, `heap_cost` of CU is consumed per additional 32k
+
+        // assert less than 32K heap should cost zero unit
+        assert_eq!(0, calculate_heap_cost(31 * 1024, heap_cost));
+
+        // assert exact 32K heap should be cost zero unit
+        assert_eq!(0, calculate_heap_cost(32 * 1024, heap_cost));
+
+        // assert slightly more than 32K heap should cost 1 * heap_cost
+        assert_eq!(heap_cost, calculate_heap_cost(33 * 1024, heap_cost));
+
+        // assert exact 64K heap should cost 1 * heap_cost
+        assert_eq!(heap_cost, calculate_heap_cost(64 * 1024, heap_cost));
+    }
+
+    fn deploy_test_program(
+        invoke_context: &mut InvokeContext,
+        program_id: Pubkey,
+    ) -> Result<(), InstructionError> {
+        let mut file = File::open("test_elfs/out/sbpfv3_return_ok.so").expect("file open failed");
+        let mut elf = Vec::new();
+        file.read_to_end(&mut elf).unwrap();
+        deploy_program!(
+            invoke_context,
+            &program_id,
+            &bpf_loader_upgradeable::id(),
+            elf.len(),
+            &elf,
+            2_u64,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_program_usage_count_on_upgrade() {
+        let transaction_accounts = vec![(
+            sysvar::epoch_schedule::id(),
+            create_account_for_test(&EpochSchedule::default()),
+        )];
+        with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
+        let program_id = Pubkey::new_unique();
+        let env = Arc::new(BuiltinProgram::new_mock());
+        let program = ProgramCacheEntry {
+            program: ProgramCacheEntryType::Unloaded(env),
+            account_owner: ProgramCacheEntryOwner::LoaderV2,
+            account_size: 0,
+            deployment_slot: 0,
+            effective_slot: 0,
+            tx_usage_counter: Arc::new(AtomicU64::new(100)),
+            latest_access_slot: AtomicU64::new(0),
+        };
+        invoke_context
+            .program_cache_for_tx_batch
+            .replenish(program_id, Arc::new(program));
+        invoke_context
+            .program_cache_for_tx_batch
+            .set_slot_for_tests(2);
+
+        assert_matches!(
+            deploy_test_program(&mut invoke_context, program_id,),
+            Ok(())
+        );
+
+        let updated_program = invoke_context
+            .program_cache_for_tx_batch
+            .find(&program_id)
+            .expect("Didn't find upgraded program in the cache");
+
+        assert_eq!(updated_program.deployment_slot, 2);
+        assert_eq!(
+            updated_program.tx_usage_counter.load(Ordering::Relaxed),
+            100
+        );
+    }
+
+    #[test]
+    fn test_program_usage_count_on_non_upgrade() {
+        let transaction_accounts = vec![(
+            sysvar::epoch_schedule::id(),
+            create_account_for_test(&EpochSchedule::default()),
+        )];
+        with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
+        let program_id = Pubkey::new_unique();
+        let env = Arc::new(BuiltinProgram::new_mock());
+        let program = ProgramCacheEntry {
+            program: ProgramCacheEntryType::Unloaded(env),
+            account_owner: ProgramCacheEntryOwner::LoaderV2,
+            account_size: 0,
+            deployment_slot: 0,
+            effective_slot: 0,
+            tx_usage_counter: Arc::new(AtomicU64::new(100)),
+            latest_access_slot: AtomicU64::new(0),
+        };
+        invoke_context
+            .program_cache_for_tx_batch
+            .replenish(program_id, Arc::new(program));
+        invoke_context
+            .program_cache_for_tx_batch
+            .set_slot_for_tests(2);
+
+        let program_id2 = Pubkey::new_unique();
+        assert_matches!(
+            deploy_test_program(&mut invoke_context, program_id2),
+            Ok(())
+        );
+
+        let program2 = invoke_context
+            .program_cache_for_tx_batch
+            .find(&program_id2)
+            .expect("Didn't find upgraded program in the cache");
+
+        assert_eq!(program2.deployment_slot, 2);
+        assert_eq!(program2.tx_usage_counter.load(Ordering::Relaxed), 0);
+    }
+}

--- a/loader-v4-program/Cargo.toml
+++ b/loader-v4-program/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "solana-loader-v4-program"
+description = "Solana Loader v4"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_loader_v4_program"
+
+[features]
+agave-unstable-api = []
+shuttle-test = [
+    "solana-program-runtime/shuttle-test",
+    "solana-sbpf/shuttle-test",
+    "solana-svm-type-overrides/shuttle-test",
+]
+svm-internal = []
+
+[dependencies]
+log = { workspace = true }
+solana-account = { workspace = true }
+solana-bincode = { workspace = true }
+solana-bpf-loader-program = { workspace = true, features = ["svm-internal"] }
+solana-instruction = { workspace = true }
+solana-loader-v3-interface = { workspace = true }
+solana-loader-v4-interface = { workspace = true, features = ["serde"] }
+solana-packet = { workspace = true }
+solana-program-runtime = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-sbpf = { workspace = true, features = ["jit"] }
+solana-sdk-ids = { workspace = true }
+solana-svm-log-collector = { workspace = true }
+solana-svm-measure = { workspace = true }
+solana-svm-type-overrides = { workspace = true }
+solana-transaction-context = { workspace = true }
+
+[dev-dependencies]
+bincode = { workspace = true }
+solana-clock = { workspace = true }
+solana-sysvar = { workspace = true }

--- a/loader-v4-program/src/lib.rs
+++ b/loader-v4-program/src/lib.rs
@@ -1,0 +1,1694 @@
+#![cfg_attr(
+    not(feature = "agave-unstable-api"),
+    deprecated(
+        since = "3.1.0",
+        note = "This crate has been marked for formal inclusion in the Agave Unstable API. From \
+                v4.0.0 onward, the `agave-unstable-api` crate feature must be specified to \
+                acknowledge use of an interface that may break without warning."
+    )
+)]
+use {
+    solana_bincode::limited_deserialize,
+    solana_bpf_loader_program::{deploy_program, execute},
+    solana_instruction::error::InstructionError,
+    solana_loader_v3_interface::state::UpgradeableLoaderState,
+    solana_loader_v4_interface::{
+        instruction::LoaderV4Instruction,
+        state::{LoaderV4State, LoaderV4Status},
+        DEPLOYMENT_COOLDOWN_IN_SLOTS,
+    },
+    solana_program_runtime::{
+        invoke_context::InvokeContext,
+        loaded_programs::{ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType},
+    },
+    solana_pubkey::Pubkey,
+    solana_sbpf::{declare_builtin_function, memory_region::MemoryMapping},
+    solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4},
+    solana_svm_log_collector::{ic_logger_msg, LogCollector},
+    solana_svm_measure::measure::Measure,
+    solana_svm_type_overrides::sync::Arc,
+    solana_transaction_context::{BorrowedInstructionAccount, InstructionContext},
+    std::{cell::RefCell, rc::Rc},
+};
+
+pub const DEFAULT_COMPUTE_UNITS: u64 = 2_000;
+
+pub fn get_state(data: &[u8]) -> Result<&LoaderV4State, InstructionError> {
+    unsafe {
+        let data = data
+            .get(0..LoaderV4State::program_data_offset())
+            .ok_or(InstructionError::AccountDataTooSmall)?
+            .try_into()
+            .unwrap();
+        Ok(std::mem::transmute::<
+            &[u8; LoaderV4State::program_data_offset()],
+            &LoaderV4State,
+        >(data))
+    }
+}
+
+fn get_state_mut(data: &mut [u8]) -> Result<&mut LoaderV4State, InstructionError> {
+    unsafe {
+        let data = data
+            .get_mut(0..LoaderV4State::program_data_offset())
+            .ok_or(InstructionError::AccountDataTooSmall)?
+            .try_into()
+            .unwrap();
+        Ok(std::mem::transmute::<
+            &mut [u8; LoaderV4State::program_data_offset()],
+            &mut LoaderV4State,
+        >(data))
+    }
+}
+
+fn check_program_account(
+    log_collector: &Option<Rc<RefCell<LogCollector>>>,
+    instruction_context: &InstructionContext,
+    program: &BorrowedInstructionAccount,
+    authority_address: &Pubkey,
+) -> Result<LoaderV4State, InstructionError> {
+    if !loader_v4::check_id(program.get_owner()) {
+        ic_logger_msg!(log_collector, "Program not owned by loader");
+        return Err(InstructionError::InvalidAccountOwner);
+    }
+    let state = get_state(program.get_data())?;
+    if !program.is_writable() {
+        ic_logger_msg!(log_collector, "Program is not writeable");
+        return Err(InstructionError::InvalidArgument);
+    }
+    if !instruction_context.is_instruction_account_signer(1)? {
+        ic_logger_msg!(log_collector, "Authority did not sign");
+        return Err(InstructionError::MissingRequiredSignature);
+    }
+    if state.authority_address_or_next_version != *authority_address {
+        ic_logger_msg!(log_collector, "Incorrect authority provided");
+        return Err(InstructionError::IncorrectAuthority);
+    }
+    if matches!(state.status, LoaderV4Status::Finalized) {
+        ic_logger_msg!(log_collector, "Program is finalized");
+        return Err(InstructionError::Immutable);
+    }
+    Ok(*state)
+}
+
+fn process_instruction_write(
+    invoke_context: &mut InvokeContext,
+    offset: u32,
+    bytes: Vec<u8>,
+) -> Result<(), InstructionError> {
+    let log_collector = invoke_context.get_log_collector();
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let mut program = instruction_context.try_borrow_instruction_account(0)?;
+    let authority_address = instruction_context.get_key_of_instruction_account(1)?;
+    let state = check_program_account(
+        &log_collector,
+        &instruction_context,
+        &program,
+        authority_address,
+    )?;
+    if !matches!(state.status, LoaderV4Status::Retracted) {
+        ic_logger_msg!(log_collector, "Program is not retracted");
+        return Err(InstructionError::InvalidArgument);
+    }
+    let destination_offset = (offset as usize).saturating_add(LoaderV4State::program_data_offset());
+    program
+        .get_data_mut()?
+        .get_mut(destination_offset..destination_offset.saturating_add(bytes.len()))
+        .ok_or_else(|| {
+            ic_logger_msg!(log_collector, "Write out of bounds");
+            InstructionError::AccountDataTooSmall
+        })?
+        .copy_from_slice(&bytes);
+    Ok(())
+}
+
+fn process_instruction_copy(
+    invoke_context: &mut InvokeContext,
+    destination_offset: u32,
+    source_offset: u32,
+    length: u32,
+) -> Result<(), InstructionError> {
+    let log_collector = invoke_context.get_log_collector();
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let mut program = instruction_context.try_borrow_instruction_account(0)?;
+    let authority_address = instruction_context.get_key_of_instruction_account(1)?;
+    let source_program = instruction_context.try_borrow_instruction_account(2)?;
+    let state = check_program_account(
+        &log_collector,
+        &instruction_context,
+        &program,
+        authority_address,
+    )?;
+    if !matches!(state.status, LoaderV4Status::Retracted) {
+        ic_logger_msg!(log_collector, "Program is not retracted");
+        return Err(InstructionError::InvalidArgument);
+    }
+    let source_owner = &source_program.get_owner();
+    let source_offset =
+        (source_offset as usize).saturating_add(if loader_v4::check_id(source_owner) {
+            LoaderV4State::program_data_offset()
+        } else if bpf_loader_upgradeable::check_id(source_owner) {
+            UpgradeableLoaderState::size_of_programdata_metadata()
+        } else if bpf_loader_deprecated::check_id(source_owner)
+            || bpf_loader::check_id(source_owner)
+        {
+            0
+        } else {
+            ic_logger_msg!(log_collector, "Source is not a program");
+            return Err(InstructionError::InvalidArgument);
+        });
+    let data = source_program
+        .get_data()
+        .get(source_offset..source_offset.saturating_add(length as usize))
+        .ok_or_else(|| {
+            ic_logger_msg!(log_collector, "Read out of bounds");
+            InstructionError::AccountDataTooSmall
+        })?;
+    let destination_offset =
+        (destination_offset as usize).saturating_add(LoaderV4State::program_data_offset());
+    program
+        .get_data_mut()?
+        .get_mut(destination_offset..destination_offset.saturating_add(length as usize))
+        .ok_or_else(|| {
+            ic_logger_msg!(log_collector, "Write out of bounds");
+            InstructionError::AccountDataTooSmall
+        })?
+        .copy_from_slice(data);
+    Ok(())
+}
+
+fn process_instruction_set_program_length(
+    invoke_context: &mut InvokeContext,
+    new_size: u32,
+) -> Result<(), InstructionError> {
+    let log_collector = invoke_context.get_log_collector();
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let mut program = instruction_context.try_borrow_instruction_account(0)?;
+    let authority_address = instruction_context.get_key_of_instruction_account(1)?;
+    let is_initialization = program.get_data().len() < LoaderV4State::program_data_offset();
+    if is_initialization {
+        if !loader_v4::check_id(program.get_owner()) {
+            ic_logger_msg!(log_collector, "Program not owned by loader");
+            return Err(InstructionError::InvalidAccountOwner);
+        }
+        if !program.is_writable() {
+            ic_logger_msg!(log_collector, "Program is not writeable");
+            return Err(InstructionError::InvalidArgument);
+        }
+        if !instruction_context.is_instruction_account_signer(1)? {
+            ic_logger_msg!(log_collector, "Authority did not sign");
+            return Err(InstructionError::MissingRequiredSignature);
+        }
+    } else {
+        let state = check_program_account(
+            &log_collector,
+            &instruction_context,
+            &program,
+            authority_address,
+        )?;
+        if !matches!(state.status, LoaderV4Status::Retracted) {
+            ic_logger_msg!(log_collector, "Program is not retracted");
+            return Err(InstructionError::InvalidArgument);
+        }
+    }
+    let required_lamports = if new_size == 0 {
+        0
+    } else {
+        let rent = invoke_context.get_sysvar_cache().get_rent()?;
+        rent.minimum_balance(LoaderV4State::program_data_offset().saturating_add(new_size as usize))
+            .max(1)
+    };
+    match program.get_lamports().cmp(&required_lamports) {
+        std::cmp::Ordering::Less => {
+            ic_logger_msg!(
+                log_collector,
+                "Insufficient lamports, {} are required",
+                required_lamports
+            );
+            return Err(InstructionError::InsufficientFunds);
+        }
+        std::cmp::Ordering::Greater => {
+            let recipient = instruction_context.try_borrow_instruction_account(2).ok();
+            if let Some(mut recipient) = recipient {
+                if !instruction_context.is_instruction_account_writable(2)? {
+                    ic_logger_msg!(log_collector, "Recipient is not writeable");
+                    return Err(InstructionError::InvalidArgument);
+                }
+                let lamports_to_receive = program.get_lamports().saturating_sub(required_lamports);
+                program.checked_sub_lamports(lamports_to_receive)?;
+                recipient.checked_add_lamports(lamports_to_receive)?;
+            } else if new_size == 0 {
+                ic_logger_msg!(
+                    log_collector,
+                    "Closing a program requires a recipient account"
+                );
+                return Err(InstructionError::InvalidArgument);
+            }
+        }
+        std::cmp::Ordering::Equal => {}
+    }
+    if new_size == 0 {
+        program.set_data_length(0)?;
+    } else {
+        program.set_data_length(
+            LoaderV4State::program_data_offset().saturating_add(new_size as usize),
+        )?;
+        if is_initialization {
+            program.set_executable(true)?;
+            let state = get_state_mut(program.get_data_mut()?)?;
+            state.slot = 0;
+            state.status = LoaderV4Status::Retracted;
+            state.authority_address_or_next_version = *authority_address;
+        }
+    }
+    Ok(())
+}
+
+fn process_instruction_deploy(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
+    let log_collector = invoke_context.get_log_collector();
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let mut program = instruction_context.try_borrow_instruction_account(0)?;
+    let authority_address = instruction_context.get_key_of_instruction_account(1)?;
+    let state = check_program_account(
+        &log_collector,
+        &instruction_context,
+        &program,
+        authority_address,
+    )?;
+    let current_slot = invoke_context.get_sysvar_cache().get_clock()?.slot;
+
+    // Slot = 0 indicates that the program hasn't been deployed yet. So no need to check for the cooldown slots.
+    // (Without this check, the program deployment is failing in freshly started test validators. That's
+    //  because at startup current_slot is 0, which is < DEPLOYMENT_COOLDOWN_IN_SLOTS).
+    if state.slot != 0 && state.slot.saturating_add(DEPLOYMENT_COOLDOWN_IN_SLOTS) > current_slot {
+        ic_logger_msg!(
+            log_collector,
+            "Program was deployed recently, cooldown still in effect"
+        );
+        return Err(InstructionError::InvalidArgument);
+    }
+    if !matches!(state.status, LoaderV4Status::Retracted) {
+        ic_logger_msg!(log_collector, "Destination program is not retracted");
+        return Err(InstructionError::InvalidArgument);
+    }
+
+    let programdata = program
+        .get_data()
+        .get(LoaderV4State::program_data_offset()..)
+        .ok_or(InstructionError::AccountDataTooSmall)?;
+    deploy_program!(
+        invoke_context,
+        program.get_key(),
+        &loader_v4::id(),
+        program.get_data().len(),
+        programdata,
+        current_slot,
+    );
+
+    let state = get_state_mut(program.get_data_mut()?)?;
+    state.slot = current_slot;
+    state.status = LoaderV4Status::Deployed;
+    Ok(())
+}
+
+fn process_instruction_retract(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
+    let log_collector = invoke_context.get_log_collector();
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let mut program = instruction_context.try_borrow_instruction_account(0)?;
+
+    let authority_address = instruction_context.get_key_of_instruction_account(1)?;
+    let state = check_program_account(
+        &log_collector,
+        &instruction_context,
+        &program,
+        authority_address,
+    )?;
+    let current_slot = invoke_context.get_sysvar_cache().get_clock()?.slot;
+    if state.slot.saturating_add(DEPLOYMENT_COOLDOWN_IN_SLOTS) > current_slot {
+        ic_logger_msg!(
+            log_collector,
+            "Program was deployed recently, cooldown still in effect"
+        );
+        return Err(InstructionError::InvalidArgument);
+    }
+    if !matches!(state.status, LoaderV4Status::Deployed) {
+        ic_logger_msg!(log_collector, "Program is not deployed");
+        return Err(InstructionError::InvalidArgument);
+    }
+    let state = get_state_mut(program.get_data_mut()?)?;
+    state.status = LoaderV4Status::Retracted;
+    invoke_context
+        .program_cache_for_tx_batch
+        .store_modified_entry(
+            *program.get_key(),
+            Arc::new(ProgramCacheEntry::new_tombstone(
+                current_slot,
+                ProgramCacheEntryOwner::LoaderV4,
+                ProgramCacheEntryType::Closed,
+            )),
+        );
+    Ok(())
+}
+
+fn process_instruction_transfer_authority(
+    invoke_context: &mut InvokeContext,
+) -> Result<(), InstructionError> {
+    let log_collector = invoke_context.get_log_collector();
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let mut program = instruction_context.try_borrow_instruction_account(0)?;
+    let authority_address = instruction_context.get_key_of_instruction_account(1)?;
+    let new_authority_address = instruction_context.get_key_of_instruction_account(2)?;
+    let state = check_program_account(
+        &log_collector,
+        &instruction_context,
+        &program,
+        authority_address,
+    )?;
+    if !instruction_context.is_instruction_account_signer(2)? {
+        ic_logger_msg!(log_collector, "New authority did not sign");
+        return Err(InstructionError::MissingRequiredSignature);
+    }
+    if state.authority_address_or_next_version == *new_authority_address {
+        ic_logger_msg!(log_collector, "No change");
+        return Err(InstructionError::InvalidArgument);
+    }
+    let state = get_state_mut(program.get_data_mut()?)?;
+    state.authority_address_or_next_version = *new_authority_address;
+    Ok(())
+}
+
+fn process_instruction_finalize(
+    invoke_context: &mut InvokeContext,
+) -> Result<(), InstructionError> {
+    let log_collector = invoke_context.get_log_collector();
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let program = instruction_context.try_borrow_instruction_account(0)?;
+    let authority_address = instruction_context.get_key_of_instruction_account(1)?;
+    let state = check_program_account(
+        &log_collector,
+        &instruction_context,
+        &program,
+        authority_address,
+    )?;
+    if !matches!(state.status, LoaderV4Status::Deployed) {
+        ic_logger_msg!(log_collector, "Program must be deployed to be finalized");
+        return Err(InstructionError::InvalidArgument);
+    }
+    drop(program);
+    let next_version = instruction_context.try_borrow_instruction_account(2)?;
+    if !loader_v4::check_id(next_version.get_owner()) {
+        ic_logger_msg!(log_collector, "Next version is not owned by loader");
+        return Err(InstructionError::InvalidAccountOwner);
+    }
+    let state_of_next_version = get_state(next_version.get_data())?;
+    if state_of_next_version.authority_address_or_next_version != *authority_address {
+        ic_logger_msg!(log_collector, "Next version has a different authority");
+        return Err(InstructionError::IncorrectAuthority);
+    }
+    if matches!(state_of_next_version.status, LoaderV4Status::Finalized) {
+        ic_logger_msg!(log_collector, "Next version is finalized");
+        return Err(InstructionError::Immutable);
+    }
+    let address_of_next_version = *next_version.get_key();
+    drop(next_version);
+    let mut program = instruction_context.try_borrow_instruction_account(0)?;
+    let state = get_state_mut(program.get_data_mut()?)?;
+    state.authority_address_or_next_version = address_of_next_version;
+    state.status = LoaderV4Status::Finalized;
+    Ok(())
+}
+
+declare_builtin_function!(
+    Entrypoint,
+    fn rust(
+        invoke_context: &mut InvokeContext<'static, 'static>,
+        _arg0: u64,
+        _arg1: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Box<dyn std::error::Error>> {
+        process_instruction_inner(invoke_context)
+    }
+);
+
+fn process_instruction_inner<'a>(
+    invoke_context: &mut InvokeContext<'a, 'a>,
+) -> Result<u64, Box<dyn std::error::Error>> {
+    let log_collector = invoke_context.get_log_collector();
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let instruction_data = instruction_context.get_instruction_data();
+    let program_id = instruction_context.get_program_key()?;
+    if loader_v4::check_id(program_id) {
+        invoke_context.consume_checked(DEFAULT_COMPUTE_UNITS)?;
+        match limited_deserialize(instruction_data, solana_packet::PACKET_DATA_SIZE as u64)? {
+            LoaderV4Instruction::Write { offset, bytes } => {
+                process_instruction_write(invoke_context, offset, bytes)
+            }
+            LoaderV4Instruction::Copy {
+                destination_offset,
+                source_offset,
+                length,
+            } => {
+                process_instruction_copy(invoke_context, destination_offset, source_offset, length)
+            }
+            LoaderV4Instruction::SetProgramLength { new_size } => {
+                process_instruction_set_program_length(invoke_context, new_size)
+            }
+            LoaderV4Instruction::Deploy => process_instruction_deploy(invoke_context),
+            LoaderV4Instruction::Retract => process_instruction_retract(invoke_context),
+            LoaderV4Instruction::TransferAuthority => {
+                process_instruction_transfer_authority(invoke_context)
+            }
+            LoaderV4Instruction::Finalize => process_instruction_finalize(invoke_context),
+        }
+        .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
+    } else {
+        let mut get_or_create_executor_time = Measure::start("get_or_create_executor_time");
+        let loaded_program = invoke_context
+            .program_cache_for_tx_batch
+            .find(program_id)
+            .ok_or_else(|| {
+                ic_logger_msg!(log_collector, "Program is not cached");
+                InstructionError::UnsupportedProgramId
+            })?;
+        get_or_create_executor_time.stop();
+        invoke_context.timings.get_or_create_executor_us += get_or_create_executor_time.as_us();
+        match &loaded_program.program {
+            ProgramCacheEntryType::FailedVerification(_)
+            | ProgramCacheEntryType::Closed
+            | ProgramCacheEntryType::DelayVisibility => {
+                ic_logger_msg!(log_collector, "Program is not deployed");
+                Err(Box::new(InstructionError::UnsupportedProgramId) as Box<dyn std::error::Error>)
+            }
+            ProgramCacheEntryType::Loaded(executable) => execute(executable, invoke_context),
+            _ => {
+                Err(Box::new(InstructionError::UnsupportedProgramId) as Box<dyn std::error::Error>)
+            }
+        }
+    }
+    .map(|_| 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_account::{
+            create_account_shared_data_for_test, AccountSharedData, ReadableAccount,
+            WritableAccount,
+        },
+        solana_bpf_loader_program::test_utils,
+        solana_clock::Slot,
+        solana_instruction::AccountMeta,
+        solana_program_runtime::invoke_context::mock_process_instruction,
+        solana_sysvar::{clock, rent},
+        solana_transaction_context::IndexOfAccount,
+        std::{fs::File, io::Read, path::Path},
+    };
+
+    fn process_instruction(
+        program_index: Option<IndexOfAccount>,
+        instruction_data: &[u8],
+        transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+        instruction_accounts: &[(IndexOfAccount, bool, bool)],
+        expected_result: Result<(), InstructionError>,
+    ) -> Vec<AccountSharedData> {
+        let instruction_accounts = instruction_accounts
+            .iter()
+            .map(
+                |(index_in_transaction, is_signer, is_writable)| AccountMeta {
+                    pubkey: transaction_accounts[*index_in_transaction as usize].0,
+                    is_signer: *is_signer,
+                    is_writable: *is_writable,
+                },
+            )
+            .collect::<Vec<_>>();
+
+        mock_process_instruction(
+            &loader_v4::id(),
+            program_index,
+            instruction_data,
+            transaction_accounts,
+            instruction_accounts,
+            expected_result,
+            Entrypoint::vm,
+            |invoke_context| {
+                test_utils::load_all_invoked_programs(invoke_context);
+            },
+            |_invoke_context| {},
+        )
+    }
+
+    fn load_program_account_from_elf(
+        authority_address: Pubkey,
+        status: LoaderV4Status,
+        path: &str,
+    ) -> AccountSharedData {
+        let path = Path::new("../bpf_loader/test_elfs/out/")
+            .join(path)
+            .with_extension("so");
+        let mut file = File::open(path).expect("file open failed");
+        let mut elf_bytes = Vec::new();
+        file.read_to_end(&mut elf_bytes).unwrap();
+        let rent = rent::Rent::default();
+        let account_size = LoaderV4State::program_data_offset().saturating_add(elf_bytes.len());
+        let mut program_account = AccountSharedData::new(
+            rent.minimum_balance(account_size),
+            account_size,
+            &loader_v4::id(),
+        );
+        let state = get_state_mut(program_account.data_as_mut_slice()).unwrap();
+        state.slot = 0;
+        state.authority_address_or_next_version = authority_address;
+        state.status = status;
+        program_account.data_as_mut_slice()[LoaderV4State::program_data_offset()..]
+            .copy_from_slice(&elf_bytes);
+        program_account
+    }
+
+    fn clock(slot: Slot) -> AccountSharedData {
+        let clock = clock::Clock {
+            slot,
+            ..clock::Clock::default()
+        };
+        create_account_shared_data_for_test(&clock)
+    }
+
+    fn test_loader_instruction_general_errors(instruction: LoaderV4Instruction) {
+        let instruction = bincode::serialize(&instruction).unwrap();
+        let authority_address = Pubkey::new_unique();
+        let transaction_accounts = vec![
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Deployed,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (
+                authority_address,
+                AccountSharedData::new(0, 0, &Pubkey::new_unique()),
+            ),
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Finalized,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (
+                clock::id(),
+                create_account_shared_data_for_test(&clock::Clock::default()),
+            ),
+            (
+                rent::id(),
+                create_account_shared_data_for_test(&rent::Rent::default()),
+            ),
+        ];
+
+        // Error: Missing program account
+        process_instruction(
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            &[],
+            Err(InstructionError::MissingAccount),
+        );
+
+        // Error: Missing authority account
+        process_instruction(
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            &[(0, false, true)],
+            Err(InstructionError::MissingAccount),
+        );
+
+        // Error: Program not owned by loader
+        process_instruction(
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            &[(1, false, true), (1, true, false), (2, true, true)],
+            Err(InstructionError::InvalidAccountOwner),
+        );
+
+        // Error: Program is not writeable
+        process_instruction(
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            &[(0, false, false), (1, true, false), (2, true, true)],
+            Err(InstructionError::InvalidArgument),
+        );
+
+        // Error: Authority did not sign
+        process_instruction(
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, false, false), (2, true, true)],
+            Err(InstructionError::MissingRequiredSignature),
+        );
+
+        // Error: Program is finalized
+        process_instruction(
+            None,
+            &instruction,
+            transaction_accounts.clone(),
+            &[(2, false, true), (1, true, false), (0, true, true)],
+            Err(InstructionError::Immutable),
+        );
+
+        // Error: Incorrect authority provided
+        process_instruction(
+            None,
+            &instruction,
+            transaction_accounts,
+            &[(0, false, true), (2, true, false), (2, true, true)],
+            Err(InstructionError::IncorrectAuthority),
+        );
+    }
+
+    #[test]
+    fn test_loader_instruction_write() {
+        let authority_address = Pubkey::new_unique();
+        let transaction_accounts = vec![
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Retracted,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (
+                authority_address,
+                AccountSharedData::new(0, 0, &Pubkey::new_unique()),
+            ),
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Deployed,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (
+                clock::id(),
+                create_account_shared_data_for_test(&clock::Clock::default()),
+            ),
+            (
+                rent::id(),
+                create_account_shared_data_for_test(&rent::Rent::default()),
+            ),
+        ];
+
+        // Overwrite existing data
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Write {
+                offset: 2,
+                bytes: vec![8, 8, 8, 8],
+            })
+            .unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false)],
+            Ok(()),
+        );
+
+        // Empty write
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Write {
+                offset: 2,
+                bytes: Vec::new(),
+            })
+            .unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false)],
+            Ok(()),
+        );
+
+        // Error: Program is not retracted
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Write {
+                offset: 8,
+                bytes: vec![8, 8, 8, 8],
+            })
+            .unwrap(),
+            transaction_accounts.clone(),
+            &[(2, false, true), (1, true, false)],
+            Err(InstructionError::InvalidArgument),
+        );
+
+        // Error: Write out of bounds
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Write {
+                offset: transaction_accounts[0]
+                    .1
+                    .data()
+                    .len()
+                    .saturating_sub(LoaderV4State::program_data_offset())
+                    .saturating_sub(3) as u32,
+                bytes: vec![8, 8, 8, 8],
+            })
+            .unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false)],
+            Err(InstructionError::AccountDataTooSmall),
+        );
+
+        test_loader_instruction_general_errors(LoaderV4Instruction::Write {
+            offset: 0,
+            bytes: Vec::new(),
+        });
+    }
+
+    #[test]
+    fn test_loader_instruction_copy() {
+        let authority_address = Pubkey::new_unique();
+        let transaction_accounts = vec![
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Retracted,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (
+                authority_address,
+                AccountSharedData::new(0, 0, &Pubkey::new_unique()),
+            ),
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Deployed,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (
+                clock::id(),
+                create_account_shared_data_for_test(&clock::Clock::default()),
+            ),
+            (
+                rent::id(),
+                create_account_shared_data_for_test(&rent::Rent::default()),
+            ),
+        ];
+
+        // Overwrite existing data
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Copy {
+                destination_offset: 1,
+                source_offset: 2,
+                length: 3,
+            })
+            .unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false), (2, false, false)],
+            Ok(()),
+        );
+
+        // Empty copy
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Copy {
+                destination_offset: 1,
+                source_offset: 2,
+                length: 0,
+            })
+            .unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false), (2, false, false)],
+            Ok(()),
+        );
+
+        // Error: Program is not retracted
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Copy {
+                destination_offset: 1,
+                source_offset: 2,
+                length: 3,
+            })
+            .unwrap(),
+            transaction_accounts.clone(),
+            &[(2, false, true), (1, true, false), (0, false, false)],
+            Err(InstructionError::InvalidArgument),
+        );
+
+        // Error: Destination and source collide
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Copy {
+                destination_offset: 1,
+                source_offset: 2,
+                length: 3,
+            })
+            .unwrap(),
+            transaction_accounts.clone(),
+            &[(2, false, true), (1, true, false), (2, false, false)],
+            Err(InstructionError::AccountBorrowFailed),
+        );
+
+        // Error: Read out of bounds
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Copy {
+                destination_offset: 1,
+                source_offset: transaction_accounts[2]
+                    .1
+                    .data()
+                    .len()
+                    .saturating_sub(LoaderV4State::program_data_offset())
+                    .saturating_sub(3) as u32,
+                length: 4,
+            })
+            .unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false), (2, false, false)],
+            Err(InstructionError::AccountDataTooSmall),
+        );
+
+        // Error: Write out of bounds
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Copy {
+                destination_offset: transaction_accounts[0]
+                    .1
+                    .data()
+                    .len()
+                    .saturating_sub(LoaderV4State::program_data_offset())
+                    .saturating_sub(3) as u32,
+                source_offset: 2,
+                length: 4,
+            })
+            .unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false), (2, false, false)],
+            Err(InstructionError::AccountDataTooSmall),
+        );
+
+        test_loader_instruction_general_errors(LoaderV4Instruction::Copy {
+            destination_offset: 1,
+            source_offset: 2,
+            length: 3,
+        });
+    }
+
+    #[test]
+    fn test_loader_instruction_truncate() {
+        let authority_address = Pubkey::new_unique();
+        let mut transaction_accounts = vec![
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Retracted,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (
+                authority_address,
+                AccountSharedData::new(0, 0, &Pubkey::new_unique()),
+            ),
+            (
+                Pubkey::new_unique(),
+                AccountSharedData::new(0, 0, &loader_v4::id()),
+            ),
+            (
+                Pubkey::new_unique(),
+                AccountSharedData::new(0, 0, &loader_v4::id()),
+            ),
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Retracted,
+                    "sbpfv3_return_ok",
+                ),
+            ),
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Deployed,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (
+                clock::id(),
+                create_account_shared_data_for_test(&clock::Clock::default()),
+            ),
+            (
+                rent::id(),
+                create_account_shared_data_for_test(&rent::Rent::default()),
+            ),
+        ];
+        let smaller_program_lamports = transaction_accounts[0].1.lamports();
+        let larger_program_lamports = transaction_accounts[4].1.lamports();
+        assert_ne!(smaller_program_lamports, larger_program_lamports);
+
+        // No change
+        let accounts = process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::SetProgramLength {
+                new_size: transaction_accounts[0]
+                    .1
+                    .data()
+                    .len()
+                    .saturating_sub(LoaderV4State::program_data_offset())
+                    as u32,
+            })
+            .unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false)],
+            Ok(()),
+        );
+        assert_eq!(
+            accounts[0].data().len(),
+            transaction_accounts[0].1.data().len(),
+        );
+        assert_eq!(accounts[2].lamports(), transaction_accounts[2].1.lamports());
+
+        // Initialize program account
+        transaction_accounts[3]
+            .1
+            .set_lamports(smaller_program_lamports);
+        let accounts = process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::SetProgramLength {
+                new_size: transaction_accounts[0]
+                    .1
+                    .data()
+                    .len()
+                    .saturating_sub(LoaderV4State::program_data_offset())
+                    as u32,
+            })
+            .unwrap(),
+            transaction_accounts.clone(),
+            &[(3, true, true), (1, true, false), (2, false, true)],
+            Ok(()),
+        );
+        assert_eq!(
+            accounts[3].data().len(),
+            transaction_accounts[0].1.data().len(),
+        );
+
+        // Increase program account size
+        transaction_accounts[0]
+            .1
+            .set_lamports(larger_program_lamports);
+        let accounts = process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::SetProgramLength {
+                new_size: transaction_accounts[4]
+                    .1
+                    .data()
+                    .len()
+                    .saturating_sub(LoaderV4State::program_data_offset())
+                    as u32,
+            })
+            .unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false)],
+            Ok(()),
+        );
+        assert_eq!(
+            accounts[0].data().len(),
+            transaction_accounts[4].1.data().len(),
+        );
+
+        // Decrease program account size, with a recipient
+        let accounts = process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::SetProgramLength {
+                new_size: transaction_accounts[0]
+                    .1
+                    .data()
+                    .len()
+                    .saturating_sub(LoaderV4State::program_data_offset())
+                    as u32,
+            })
+            .unwrap(),
+            transaction_accounts.clone(),
+            &[(4, false, true), (1, true, false), (2, false, true)],
+            Ok(()),
+        );
+        assert_eq!(
+            accounts[4].data().len(),
+            transaction_accounts[0].1.data().len(),
+        );
+        assert_eq!(
+            accounts[2].lamports(),
+            transaction_accounts[2].1.lamports().saturating_add(
+                transaction_accounts[4]
+                    .1
+                    .lamports()
+                    .saturating_sub(accounts[4].lamports())
+            ),
+        );
+
+        // Decrease program account size, without a recipient
+        let accounts = process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::SetProgramLength {
+                new_size: transaction_accounts[0]
+                    .1
+                    .data()
+                    .len()
+                    .saturating_sub(LoaderV4State::program_data_offset())
+                    as u32,
+            })
+            .unwrap(),
+            transaction_accounts.clone(),
+            &[(4, false, true), (1, true, false)],
+            Ok(()),
+        );
+        assert_eq!(
+            accounts[4].data().len(),
+            transaction_accounts[0].1.data().len(),
+        );
+        assert_eq!(accounts[2].lamports(), transaction_accounts[2].1.lamports(),);
+
+        // Close program account
+        let accounts = process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::SetProgramLength { new_size: 0 }).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false), (2, false, true)],
+            Ok(()),
+        );
+        assert_eq!(accounts[0].data().len(), 0);
+        assert_eq!(
+            accounts[2].lamports(),
+            transaction_accounts[2].1.lamports().saturating_add(
+                transaction_accounts[0]
+                    .1
+                    .lamports()
+                    .saturating_sub(accounts[0].lamports())
+            ),
+        );
+
+        // Close uninitialized program account
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::SetProgramLength { new_size: 0 }).unwrap(),
+            transaction_accounts.clone(),
+            &[(3, false, true), (1, true, false), (2, true, true)],
+            Ok(()),
+        );
+
+        // Error: Program not owned by loader
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::SetProgramLength { new_size: 8 }).unwrap(),
+            transaction_accounts.clone(),
+            &[(1, false, true), (1, true, false), (2, true, true)],
+            Err(InstructionError::InvalidAccountOwner),
+        );
+
+        // Error: Program is not writeable
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::SetProgramLength { new_size: 8 }).unwrap(),
+            transaction_accounts.clone(),
+            &[(3, false, false), (1, true, false), (2, true, true)],
+            Err(InstructionError::InvalidArgument),
+        );
+
+        // Error: Close program account without a recipient
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::SetProgramLength { new_size: 0 }).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false)],
+            Err(InstructionError::InvalidArgument),
+        );
+
+        // Error: Authority did not sign
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::SetProgramLength { new_size: 8 }).unwrap(),
+            transaction_accounts.clone(),
+            &[(3, true, true), (1, false, false), (2, true, true)],
+            Err(InstructionError::MissingRequiredSignature),
+        );
+
+        // Error: Program is not retracted
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::SetProgramLength { new_size: 8 }).unwrap(),
+            transaction_accounts.clone(),
+            &[(5, false, true), (1, true, false), (2, false, true)],
+            Err(InstructionError::InvalidArgument),
+        );
+
+        // Error: Recipient is not writeable
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::SetProgramLength { new_size: 0 }).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false), (2, false, false)],
+            Err(InstructionError::InvalidArgument),
+        );
+
+        // Error: Insufficient funds
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::SetProgramLength {
+                new_size: transaction_accounts[4]
+                    .1
+                    .data()
+                    .len()
+                    .saturating_sub(LoaderV4State::program_data_offset())
+                    .saturating_add(1) as u32,
+            })
+            .unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false)],
+            Err(InstructionError::InsufficientFunds),
+        );
+
+        test_loader_instruction_general_errors(LoaderV4Instruction::SetProgramLength {
+            new_size: 0,
+        });
+    }
+
+    #[test]
+    fn test_loader_instruction_deploy() {
+        let authority_address = Pubkey::new_unique();
+        let mut transaction_accounts = vec![
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Retracted,
+                    "sbpfv3_return_ok",
+                ),
+            ),
+            (
+                authority_address,
+                AccountSharedData::new(0, 0, &Pubkey::new_unique()),
+            ),
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Retracted,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (
+                Pubkey::new_unique(),
+                AccountSharedData::new(0, 0, &loader_v4::id()),
+            ),
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Retracted,
+                    "sbpfv0_verifier_err",
+                ),
+            ),
+            (clock::id(), clock(1000)),
+            (
+                rent::id(),
+                create_account_shared_data_for_test(&rent::Rent::default()),
+            ),
+        ];
+
+        // Deploy from its own data
+        let accounts = process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Deploy).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false)],
+            Ok(()),
+        );
+        transaction_accounts[0].1 = accounts[0].clone();
+        transaction_accounts[5].1 = clock(2000);
+        assert_eq!(
+            accounts[0].data().len(),
+            transaction_accounts[0].1.data().len(),
+        );
+        assert_eq!(accounts[0].lamports(), transaction_accounts[0].1.lamports());
+
+        // Error: Program was deployed recently, cooldown still in effect
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Deploy).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false)],
+            Err(InstructionError::InvalidArgument),
+        );
+        transaction_accounts[5].1 = clock(3000);
+
+        // Error: Program is uninitialized
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Deploy).unwrap(),
+            transaction_accounts.clone(),
+            &[(3, false, true), (1, true, false)],
+            Err(InstructionError::AccountDataTooSmall),
+        );
+
+        // Error: Program fails verification
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Deploy).unwrap(),
+            transaction_accounts.clone(),
+            &[(4, false, true), (1, true, false)],
+            Err(InstructionError::InvalidAccountData),
+        );
+
+        // Error: Program is deployed already
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Deploy).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false)],
+            Err(InstructionError::InvalidArgument),
+        );
+
+        test_loader_instruction_general_errors(LoaderV4Instruction::Deploy);
+    }
+
+    #[test]
+    fn test_loader_instruction_retract() {
+        let authority_address = Pubkey::new_unique();
+        let mut transaction_accounts = vec![
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Deployed,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (
+                authority_address,
+                AccountSharedData::new(0, 0, &Pubkey::new_unique()),
+            ),
+            (
+                Pubkey::new_unique(),
+                AccountSharedData::new(0, 0, &loader_v4::id()),
+            ),
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Retracted,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (clock::id(), clock(1000)),
+            (
+                rent::id(),
+                create_account_shared_data_for_test(&rent::Rent::default()),
+            ),
+        ];
+
+        // Retract program
+        let accounts = process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Retract).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false)],
+            Ok(()),
+        );
+        assert_eq!(
+            accounts[0].data().len(),
+            transaction_accounts[0].1.data().len(),
+        );
+        assert_eq!(accounts[0].lamports(), transaction_accounts[0].1.lamports());
+
+        // Error: Program is uninitialized
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Retract).unwrap(),
+            transaction_accounts.clone(),
+            &[(2, false, true), (1, true, false)],
+            Err(InstructionError::AccountDataTooSmall),
+        );
+
+        // Error: Program is not deployed
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Retract).unwrap(),
+            transaction_accounts.clone(),
+            &[(3, false, true), (1, true, false)],
+            Err(InstructionError::InvalidArgument),
+        );
+
+        // Error: Program was deployed recently, cooldown still in effect
+        transaction_accounts[4].1 = clock(0);
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Retract).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (1, true, false)],
+            Err(InstructionError::InvalidArgument),
+        );
+
+        test_loader_instruction_general_errors(LoaderV4Instruction::Retract);
+    }
+
+    #[test]
+    fn test_loader_instruction_transfer_authority() {
+        let authority_address = Pubkey::new_unique();
+        let transaction_accounts = vec![
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Deployed,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Retracted,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (
+                Pubkey::new_unique(),
+                AccountSharedData::new(0, 0, &loader_v4::id()),
+            ),
+            (
+                authority_address,
+                AccountSharedData::new(0, 0, &Pubkey::new_unique()),
+            ),
+            (
+                Pubkey::new_unique(),
+                AccountSharedData::new(0, 0, &Pubkey::new_unique()),
+            ),
+            (
+                clock::id(),
+                create_account_shared_data_for_test(&clock::Clock::default()),
+            ),
+            (
+                rent::id(),
+                create_account_shared_data_for_test(&rent::Rent::default()),
+            ),
+        ];
+
+        // Transfer authority
+        let accounts = process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::TransferAuthority).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (3, true, false), (4, true, false)],
+            Ok(()),
+        );
+        assert_eq!(
+            accounts[0].data().len(),
+            transaction_accounts[0].1.data().len(),
+        );
+        assert_eq!(accounts[0].lamports(), transaction_accounts[0].1.lamports());
+
+        // Error: No new authority provided
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::TransferAuthority).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (3, true, false)],
+            Err(InstructionError::MissingAccount),
+        );
+
+        // Error: Program is uninitialized
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::TransferAuthority).unwrap(),
+            transaction_accounts.clone(),
+            &[(2, false, true), (3, true, false), (4, true, false)],
+            Err(InstructionError::AccountDataTooSmall),
+        );
+
+        // Error: New authority did not sign
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::TransferAuthority).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (3, true, false), (4, false, false)],
+            Err(InstructionError::MissingRequiredSignature),
+        );
+
+        // Error: Authority did not change
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::TransferAuthority).unwrap(),
+            transaction_accounts,
+            &[(0, false, true), (3, true, false), (3, true, false)],
+            Err(InstructionError::InvalidArgument),
+        );
+
+        test_loader_instruction_general_errors(LoaderV4Instruction::TransferAuthority);
+    }
+
+    #[test]
+    fn test_loader_instruction_finalize() {
+        let authority_address = Pubkey::new_unique();
+        let transaction_accounts = vec![
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Deployed,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Retracted,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Finalized,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    Pubkey::new_unique(),
+                    LoaderV4Status::Retracted,
+                    "sbpfv3_return_err",
+                ),
+            ),
+            (
+                Pubkey::new_unique(),
+                AccountSharedData::new(0, 0, &loader_v4::id()),
+            ),
+            (
+                authority_address,
+                AccountSharedData::new(0, 0, &Pubkey::new_unique()),
+            ),
+            (
+                clock::id(),
+                create_account_shared_data_for_test(&clock::Clock::default()),
+            ),
+            (
+                rent::id(),
+                create_account_shared_data_for_test(&rent::Rent::default()),
+            ),
+        ];
+
+        // Finalize program with a next version
+        let accounts = process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Finalize).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (5, true, false), (1, false, false)],
+            Ok(()),
+        );
+        assert_eq!(
+            accounts[0].data().len(),
+            transaction_accounts[0].1.data().len(),
+        );
+        assert_eq!(accounts[0].lamports(), transaction_accounts[0].1.lamports());
+
+        // Finalize program with itself as next version
+        let accounts = process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Finalize).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (5, true, false), (0, false, false)],
+            Ok(()),
+        );
+        assert_eq!(
+            accounts[0].data().len(),
+            transaction_accounts[0].1.data().len(),
+        );
+        assert_eq!(accounts[0].lamports(), transaction_accounts[0].1.lamports());
+
+        // Error: Program must be deployed to be finalized
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Finalize).unwrap(),
+            transaction_accounts.clone(),
+            &[(1, false, true), (5, true, false)],
+            Err(InstructionError::InvalidArgument),
+        );
+
+        // Error: Program is uninitialized
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Finalize).unwrap(),
+            transaction_accounts.clone(),
+            &[(4, false, true), (5, true, false)],
+            Err(InstructionError::AccountDataTooSmall),
+        );
+
+        // Error: Next version not owned by loader
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Finalize).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (5, true, false), (5, false, false)],
+            Err(InstructionError::InvalidAccountOwner),
+        );
+
+        // Error: Program is uninitialized
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Finalize).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (5, true, false), (4, false, false)],
+            Err(InstructionError::AccountDataTooSmall),
+        );
+
+        // Error: Next version is finalized
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Finalize).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (5, true, false), (2, false, false)],
+            Err(InstructionError::Immutable),
+        );
+
+        // Error: Incorrect authority of next version
+        process_instruction(
+            None,
+            &bincode::serialize(&LoaderV4Instruction::Finalize).unwrap(),
+            transaction_accounts.clone(),
+            &[(0, false, true), (5, true, false), (3, false, false)],
+            Err(InstructionError::IncorrectAuthority),
+        );
+
+        test_loader_instruction_general_errors(LoaderV4Instruction::TransferAuthority);
+    }
+
+    #[test]
+    fn test_execute_program() {
+        let program_address = Pubkey::new_unique();
+        let authority_address = Pubkey::new_unique();
+        let transaction_accounts = vec![
+            (
+                program_address,
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Finalized,
+                    "sbpfv3_return_ok",
+                ),
+            ),
+            (
+                Pubkey::new_unique(),
+                AccountSharedData::new(10000000, 32, &program_address),
+            ),
+            (
+                Pubkey::new_unique(),
+                AccountSharedData::new(0, 0, &loader_v4::id()),
+            ),
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Retracted,
+                    "sbpfv3_return_ok",
+                ),
+            ),
+            (
+                Pubkey::new_unique(),
+                load_program_account_from_elf(
+                    authority_address,
+                    LoaderV4Status::Finalized,
+                    "sbpfv0_verifier_err",
+                ),
+            ),
+        ];
+
+        // Execute program
+        process_instruction(
+            Some(0),
+            &[0, 1, 2, 3],
+            transaction_accounts.clone(),
+            &[(1, false, true)],
+            Ok(()),
+        );
+
+        // Error: Program not owned by loader
+        process_instruction(
+            Some(1),
+            &[0, 1, 2, 3],
+            transaction_accounts.clone(),
+            &[(1, false, true)],
+            Err(InstructionError::UnsupportedProgramId),
+        );
+
+        // Error: Program is uninitialized
+        process_instruction(
+            Some(2),
+            &[0, 1, 2, 3],
+            transaction_accounts.clone(),
+            &[(1, false, true)],
+            Err(InstructionError::UnsupportedProgramId),
+        );
+
+        // Error: Program is not deployed
+        // This is only checked in integration with load_program_accounts() in the SVM
+        process_instruction(
+            Some(3),
+            &[0, 1, 2, 3],
+            transaction_accounts.clone(),
+            &[(1, false, true)],
+            Ok(()),
+        );
+
+        // Error: Program fails verification
+        process_instruction(
+            Some(4),
+            &[0, 1, 2, 3],
+            transaction_accounts,
+            &[(1, false, true)],
+            Err(InstructionError::UnsupportedProgramId),
+        );
+    }
+}

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -247,7 +247,7 @@ pub struct CallerAccount<'a> {
 
 impl<'a> CallerAccount<'a> {
     pub fn get_serialized_data(
-        memory_mapping: &solana_sbpf::memory_region::MemoryMapping<'_>,
+        memory_mapping: &solana_sbpf::memory_region::MemoryMapping,
         vm_addr: u64,
         len: u64,
         stricter_abi_and_runtime_constraints: bool,
@@ -286,7 +286,7 @@ impl<'a> CallerAccount<'a> {
     // Create a CallerAccount given an AccountInfo.
     pub fn from_account_info(
         invoke_context: &InvokeContext,
-        memory_mapping: &solana_sbpf::memory_region::MemoryMapping<'_>,
+        memory_mapping: &solana_sbpf::memory_region::MemoryMapping,
         check_aligned: bool,
         _vm_addr: u64,
         account_info: &solana_account_info::AccountInfo,
@@ -409,7 +409,7 @@ impl<'a> CallerAccount<'a> {
     // Create a CallerAccount given a SolAccountInfo.
     fn from_sol_account_info(
         invoke_context: &InvokeContext,
-        memory_mapping: &solana_sbpf::memory_region::MemoryMapping<'_>,
+        memory_mapping: &solana_sbpf::memory_region::MemoryMapping,
         check_aligned: bool,
         vm_addr: u64,
         account_info: &SolAccountInfo,
@@ -513,7 +513,7 @@ pub trait SyscallInvokeSigned {
     fn translate_accounts<'a>(
         account_infos_addr: u64,
         account_infos_len: u64,
-        memory_mapping: &MemoryMapping<'_>,
+        memory_mapping: &MemoryMapping,
         invoke_context: &mut InvokeContext,
         check_aligned: bool,
     ) -> Result<Vec<TranslatedAccount<'a>>, Error>;
@@ -592,7 +592,7 @@ pub fn translate_instruction_rust(
 pub fn translate_accounts_rust<'a>(
     account_infos_addr: u64,
     account_infos_len: u64,
-    memory_mapping: &MemoryMapping<'_>,
+    memory_mapping: &MemoryMapping,
     invoke_context: &mut InvokeContext,
     check_aligned: bool,
 ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
@@ -730,7 +730,7 @@ pub fn translate_instruction_c(
 pub fn translate_accounts_c<'a>(
     account_infos_addr: u64,
     account_infos_len: u64,
-    memory_mapping: &MemoryMapping<'_>,
+    memory_mapping: &MemoryMapping,
     invoke_context: &mut InvokeContext,
     check_aligned: bool,
 ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
@@ -1000,14 +1000,14 @@ fn translate_accounts_common<'a, T, F>(
     account_infos: &[T],
     account_infos_addr: u64,
     invoke_context: &mut InvokeContext,
-    memory_mapping: &MemoryMapping<'_>,
+    memory_mapping: &MemoryMapping,
     check_aligned: bool,
     do_translate: F,
 ) -> Result<Vec<TranslatedAccount<'a>>, Error>
 where
     F: Fn(
         &InvokeContext,
-        &MemoryMapping<'_>,
+        &MemoryMapping,
         bool,
         u64,
         &T,
@@ -1265,7 +1265,7 @@ fn update_caller_account_region(
 // accounts (regardless of the current size of an account).
 fn update_caller_account(
     invoke_context: &InvokeContext,
-    memory_mapping: &MemoryMapping<'_>,
+    memory_mapping: &MemoryMapping,
     check_aligned: bool,
     caller_account: &mut CallerAccount<'_>,
     callee_account: &mut BorrowedInstructionAccount<'_, '_>,

--- a/syscalls/Cargo.toml
+++ b/syscalls/Cargo.toml
@@ -1,0 +1,79 @@
+[package]
+name = "agave-syscalls"
+description = "Agave implementation of the Solana syscalls."
+documentation = "https://docs.rs/agave-syscalls"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+default = ["metrics"]
+agave-unstable-api = []
+metrics = ["solana-program-runtime/metrics"]
+shuttle-test = [
+    "solana-program-runtime/shuttle-test",
+    "solana-sbpf/shuttle-test",
+    "solana-svm-type-overrides/shuttle-test",
+]
+svm-internal = []
+
+[dependencies]
+bincode = { workspace = true }
+libsecp256k1 = { workspace = true }
+num-traits = { workspace = true }
+solana-account = { workspace = true }
+solana-account-info = { workspace = true }
+solana-big-mod-exp = { workspace = true }
+solana-blake3-hasher = { workspace = true, features = ["blake3"] }
+solana-bn254 = { workspace = true }
+solana-clock = { workspace = true }
+solana-cpi = { workspace = true }
+solana-curve25519 = { workspace = true }
+solana-hash = { workspace = true }
+solana-instruction = { workspace = true }
+solana-keccak-hasher = { workspace = true, features = ["sha3"] }
+solana-loader-v3-interface = { workspace = true, features = ["serde"] }
+solana-poseidon = { workspace = true }
+solana-program-entrypoint = { workspace = true }
+solana-program-runtime = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-sbpf = { workspace = true, features = ["jit"] }
+solana-sdk-ids = { workspace = true }
+solana-secp256k1-recover = { workspace = true }
+solana-sha256-hasher = { workspace = true }
+solana-stable-layout = { workspace = true }
+solana-stake-interface = { workspace = true }
+solana-svm-callback = { workspace = true }
+solana-svm-feature-set = { workspace = true }
+solana-svm-log-collector = { workspace = true }
+solana-svm-measure = { workspace = true }
+solana-svm-timings = { workspace = true }
+solana-svm-type-overrides = { workspace = true }
+solana-sysvar = { workspace = true }
+solana-sysvar-id = { workspace = true }
+solana-transaction-context = { workspace = true, features = ["bincode"] }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+assert_matches = { workspace = true }
+solana-epoch-rewards = { workspace = true }
+solana-epoch-schedule = { workspace = true }
+solana-fee-calculator = { workspace = true }
+solana-last-restart-slot = { workspace = true }
+solana-program = { workspace = true }
+solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-pubkey = { workspace = true, features = ["rand"] }
+solana-rent = { workspace = true }
+solana-slot-hashes = { workspace = true }
+solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
+static_assertions = { workspace = true }
+test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -1,0 +1,143 @@
+use {
+    super::*,
+    solana_instruction::Instruction,
+    solana_program_runtime::cpi::{
+        cpi_common, translate_accounts_c, translate_accounts_rust, translate_instruction_c,
+        translate_instruction_rust, translate_signers_c, translate_signers_rust,
+        SyscallInvokeSigned, TranslatedAccount,
+    },
+};
+
+declare_builtin_function!(
+    /// Cross-program invocation called from Rust
+    SyscallInvokeSignedRust,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        instruction_addr: u64,
+        account_infos_addr: u64,
+        account_infos_len: u64,
+        signers_seeds_addr: u64,
+        signers_seeds_len: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        cpi_common::<Self>(
+            invoke_context,
+            instruction_addr,
+            account_infos_addr,
+            account_infos_len,
+            signers_seeds_addr,
+            signers_seeds_len,
+            memory_mapping,
+        )
+    }
+);
+
+impl SyscallInvokeSigned for SyscallInvokeSignedRust {
+    fn translate_instruction(
+        addr: u64,
+        memory_mapping: &MemoryMapping,
+        invoke_context: &mut InvokeContext,
+        check_aligned: bool,
+    ) -> Result<Instruction, Error> {
+        translate_instruction_rust(addr, memory_mapping, invoke_context, check_aligned)
+    }
+
+    fn translate_accounts<'a>(
+        account_infos_addr: u64,
+        account_infos_len: u64,
+        memory_mapping: &MemoryMapping,
+        invoke_context: &mut InvokeContext,
+        check_aligned: bool,
+    ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
+        translate_accounts_rust(
+            account_infos_addr,
+            account_infos_len,
+            memory_mapping,
+            invoke_context,
+            check_aligned,
+        )
+    }
+
+    fn translate_signers(
+        program_id: &Pubkey,
+        signers_seeds_addr: u64,
+        signers_seeds_len: u64,
+        memory_mapping: &MemoryMapping,
+        check_aligned: bool,
+    ) -> Result<Vec<Pubkey>, Error> {
+        translate_signers_rust(
+            program_id,
+            signers_seeds_addr,
+            signers_seeds_len,
+            memory_mapping,
+            check_aligned,
+        )
+    }
+}
+
+declare_builtin_function!(
+    /// Cross-program invocation called from C
+    SyscallInvokeSignedC,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        instruction_addr: u64,
+        account_infos_addr: u64,
+        account_infos_len: u64,
+        signers_seeds_addr: u64,
+        signers_seeds_len: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        cpi_common::<Self>(
+            invoke_context,
+            instruction_addr,
+            account_infos_addr,
+            account_infos_len,
+            signers_seeds_addr,
+            signers_seeds_len,
+            memory_mapping,
+        )
+    }
+);
+
+impl SyscallInvokeSigned for SyscallInvokeSignedC {
+    fn translate_instruction(
+        addr: u64,
+        memory_mapping: &MemoryMapping,
+        invoke_context: &mut InvokeContext,
+        check_aligned: bool,
+    ) -> Result<Instruction, Error> {
+        translate_instruction_c(addr, memory_mapping, invoke_context, check_aligned)
+    }
+
+    fn translate_accounts<'a>(
+        account_infos_addr: u64,
+        account_infos_len: u64,
+        memory_mapping: &MemoryMapping,
+        invoke_context: &mut InvokeContext,
+        check_aligned: bool,
+    ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
+        translate_accounts_c(
+            account_infos_addr,
+            account_infos_len,
+            memory_mapping,
+            invoke_context,
+            check_aligned,
+        )
+    }
+
+    fn translate_signers(
+        program_id: &Pubkey,
+        signers_seeds_addr: u64,
+        signers_seeds_len: u64,
+        memory_mapping: &MemoryMapping,
+        check_aligned: bool,
+    ) -> Result<Vec<Pubkey>, Error> {
+        translate_signers_c(
+            program_id,
+            signers_seeds_addr,
+            signers_seeds_len,
+            memory_mapping,
+            check_aligned,
+        )
+    }
+}

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -1,0 +1,5153 @@
+#![cfg_attr(
+    not(feature = "agave-unstable-api"),
+    deprecated(
+        since = "3.1.0",
+        note = "This crate has been marked for formal inclusion in the Agave Unstable API. From \
+                v4.0.0 onward, the `agave-unstable-api` crate feature must be specified to \
+                acknowledge use of an interface that may break without warning."
+    )
+)]
+pub use self::{
+    cpi::{SyscallInvokeSignedC, SyscallInvokeSignedRust},
+    logging::{
+        SyscallLog, SyscallLogBpfComputeUnits, SyscallLogData, SyscallLogPubkey, SyscallLogU64,
+    },
+    mem_ops::{SyscallMemcmp, SyscallMemcpy, SyscallMemmove, SyscallMemset},
+    sysvar::{
+        SyscallGetClockSysvar, SyscallGetEpochRewardsSysvar, SyscallGetEpochScheduleSysvar,
+        SyscallGetFeesSysvar, SyscallGetLastRestartSlotSysvar, SyscallGetRentSysvar,
+        SyscallGetSysvar,
+    },
+};
+use solana_program_runtime::memory::translate_vm_slice;
+#[allow(deprecated)]
+use {
+    crate::mem_ops::is_nonoverlapping,
+    solana_big_mod_exp::{big_mod_exp, BigModExpParams},
+    solana_blake3_hasher as blake3,
+    solana_cpi::MAX_RETURN_DATA,
+    solana_hash::Hash,
+    solana_instruction::{error::InstructionError, AccountMeta, ProcessedSiblingInstruction},
+    solana_keccak_hasher as keccak, solana_poseidon as poseidon,
+    solana_program_entrypoint::{BPF_ALIGN_OF_U128, SUCCESS},
+    solana_program_runtime::{
+        cpi::CpiError,
+        execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
+        invoke_context::InvokeContext,
+        memory::MemoryTranslationError,
+        stable_log, translate_inner, translate_slice_inner, translate_type_inner,
+    },
+    solana_pubkey::{Pubkey, PubkeyError, MAX_SEEDS, MAX_SEED_LEN, PUBKEY_BYTES},
+    solana_sbpf::{
+        declare_builtin_function,
+        memory_region::{AccessType, MemoryMapping},
+        program::{BuiltinProgram, SBPFVersion},
+        vm::Config,
+    },
+    solana_secp256k1_recover::{
+        Secp256k1RecoverError, SECP256K1_PUBLIC_KEY_LENGTH, SECP256K1_SIGNATURE_LENGTH,
+    },
+    solana_sha256_hasher::Hasher,
+    solana_svm_feature_set::SVMFeatureSet,
+    solana_svm_log_collector::{ic_logger_msg, ic_msg},
+    solana_svm_type_overrides::sync::Arc,
+    solana_sysvar::SysvarSerialize,
+    solana_transaction_context::vm_slice::VmSlice,
+    std::{
+        alloc::Layout,
+        mem::{align_of, size_of},
+        slice::from_raw_parts_mut,
+        str::{from_utf8, Utf8Error},
+    },
+    thiserror::Error as ThisError,
+};
+
+mod cpi;
+mod logging;
+mod mem_ops;
+mod sysvar;
+
+/// Error definitions
+#[derive(Debug, ThisError, PartialEq, Eq)]
+pub enum SyscallError {
+    #[error("{0}: {1:?}")]
+    InvalidString(Utf8Error, Vec<u8>),
+    #[error("SBF program panicked")]
+    Abort,
+    #[error("SBF program Panicked in {0} at {1}:{2}")]
+    Panic(String, u64, u64),
+    #[error("Cannot borrow invoke context")]
+    InvokeContextBorrowFailed,
+    #[error("Malformed signer seed: {0}: {1:?}")]
+    MalformedSignerSeed(Utf8Error, Vec<u8>),
+    #[error("Could not create program address with signer seeds: {0}")]
+    BadSeeds(PubkeyError),
+    #[error("Program {0} not supported by inner instructions")]
+    ProgramNotSupported(Pubkey),
+    #[error("Unaligned pointer")]
+    UnalignedPointer,
+    #[error("Too many signers")]
+    TooManySigners,
+    #[error("Instruction passed to inner instruction is too large ({0} > {1})")]
+    InstructionTooLarge(usize, usize),
+    #[error("Too many accounts passed to inner instruction")]
+    TooManyAccounts,
+    #[error("Overlapping copy")]
+    CopyOverlapping,
+    #[error("Return data too large ({0} > {1})")]
+    ReturnDataTooLarge(u64, u64),
+    #[error("Hashing too many sequences")]
+    TooManySlices,
+    #[error("InvalidLength")]
+    InvalidLength,
+    #[error("Invoked an instruction with data that is too large ({data_len} > {max_data_len})")]
+    MaxInstructionDataLenExceeded { data_len: u64, max_data_len: u64 },
+    #[error("Invoked an instruction with too many accounts ({num_accounts} > {max_accounts})")]
+    MaxInstructionAccountsExceeded {
+        num_accounts: u64,
+        max_accounts: u64,
+    },
+    #[error(
+        "Invoked an instruction with too many account info's ({num_account_infos} > \
+         {max_account_infos})"
+    )]
+    MaxInstructionAccountInfosExceeded {
+        num_account_infos: u64,
+        max_account_infos: u64,
+    },
+    #[error("InvalidAttribute")]
+    InvalidAttribute,
+    #[error("Invalid pointer")]
+    InvalidPointer,
+    #[error("Arithmetic overflow")]
+    ArithmeticOverflow,
+}
+
+impl From<MemoryTranslationError> for SyscallError {
+    fn from(error: MemoryTranslationError) -> Self {
+        match error {
+            MemoryTranslationError::UnalignedPointer => SyscallError::UnalignedPointer,
+            MemoryTranslationError::InvalidLength => SyscallError::InvalidLength,
+        }
+    }
+}
+
+impl From<CpiError> for SyscallError {
+    fn from(error: CpiError) -> Self {
+        match error {
+            CpiError::InvalidPointer => SyscallError::InvalidPointer,
+            CpiError::TooManySigners => SyscallError::TooManySigners,
+            CpiError::BadSeeds(e) => SyscallError::BadSeeds(e),
+            CpiError::InvalidLength => SyscallError::InvalidLength,
+            CpiError::MaxInstructionAccountsExceeded {
+                num_accounts,
+                max_accounts,
+            } => SyscallError::MaxInstructionAccountsExceeded {
+                num_accounts,
+                max_accounts,
+            },
+            CpiError::MaxInstructionDataLenExceeded {
+                data_len,
+                max_data_len,
+            } => SyscallError::MaxInstructionDataLenExceeded {
+                data_len,
+                max_data_len,
+            },
+            CpiError::MaxInstructionAccountInfosExceeded {
+                num_account_infos,
+                max_account_infos,
+            } => SyscallError::MaxInstructionAccountInfosExceeded {
+                num_account_infos,
+                max_account_infos,
+            },
+            CpiError::ProgramNotSupported(pubkey) => SyscallError::ProgramNotSupported(pubkey),
+        }
+    }
+}
+
+type Error = Box<dyn std::error::Error>;
+
+trait HasherImpl {
+    const NAME: &'static str;
+    type Output: AsRef<[u8]>;
+
+    fn create_hasher() -> Self;
+    fn hash(&mut self, val: &[u8]);
+    fn result(self) -> Self::Output;
+    fn get_base_cost(compute_cost: &SVMTransactionExecutionCost) -> u64;
+    fn get_byte_cost(compute_cost: &SVMTransactionExecutionCost) -> u64;
+    fn get_max_slices(compute_budget: &SVMTransactionExecutionBudget) -> u64;
+}
+
+struct Sha256Hasher(Hasher);
+struct Blake3Hasher(blake3::Hasher);
+struct Keccak256Hasher(keccak::Hasher);
+
+impl HasherImpl for Sha256Hasher {
+    const NAME: &'static str = "Sha256";
+    type Output = Hash;
+
+    fn create_hasher() -> Self {
+        Sha256Hasher(Hasher::default())
+    }
+
+    fn hash(&mut self, val: &[u8]) {
+        self.0.hash(val);
+    }
+
+    fn result(self) -> Self::Output {
+        self.0.result()
+    }
+
+    fn get_base_cost(compute_cost: &SVMTransactionExecutionCost) -> u64 {
+        compute_cost.sha256_base_cost
+    }
+    fn get_byte_cost(compute_cost: &SVMTransactionExecutionCost) -> u64 {
+        compute_cost.sha256_byte_cost
+    }
+    fn get_max_slices(compute_budget: &SVMTransactionExecutionBudget) -> u64 {
+        compute_budget.sha256_max_slices
+    }
+}
+
+impl HasherImpl for Blake3Hasher {
+    const NAME: &'static str = "Blake3";
+    type Output = blake3::Hash;
+
+    fn create_hasher() -> Self {
+        Blake3Hasher(blake3::Hasher::default())
+    }
+
+    fn hash(&mut self, val: &[u8]) {
+        self.0.hash(val);
+    }
+
+    fn result(self) -> Self::Output {
+        self.0.result()
+    }
+
+    fn get_base_cost(compute_cost: &SVMTransactionExecutionCost) -> u64 {
+        compute_cost.sha256_base_cost
+    }
+    fn get_byte_cost(compute_cost: &SVMTransactionExecutionCost) -> u64 {
+        compute_cost.sha256_byte_cost
+    }
+    fn get_max_slices(compute_budget: &SVMTransactionExecutionBudget) -> u64 {
+        compute_budget.sha256_max_slices
+    }
+}
+
+impl HasherImpl for Keccak256Hasher {
+    const NAME: &'static str = "Keccak256";
+    type Output = keccak::Hash;
+
+    fn create_hasher() -> Self {
+        Keccak256Hasher(keccak::Hasher::default())
+    }
+
+    fn hash(&mut self, val: &[u8]) {
+        self.0.hash(val);
+    }
+
+    fn result(self) -> Self::Output {
+        self.0.result()
+    }
+
+    fn get_base_cost(compute_cost: &SVMTransactionExecutionCost) -> u64 {
+        compute_cost.sha256_base_cost
+    }
+    fn get_byte_cost(compute_cost: &SVMTransactionExecutionCost) -> u64 {
+        compute_cost.sha256_byte_cost
+    }
+    fn get_max_slices(compute_budget: &SVMTransactionExecutionBudget) -> u64 {
+        compute_budget.sha256_max_slices
+    }
+}
+
+fn consume_compute_meter(invoke_context: &InvokeContext, amount: u64) -> Result<(), Error> {
+    invoke_context.consume_checked(amount)?;
+    Ok(())
+}
+
+macro_rules! register_feature_gated_function {
+    ($result:expr, $is_feature_active:expr, $name:expr, $call:expr $(,)?) => {
+        if $is_feature_active {
+            $result.register_function($name, $call)
+        } else {
+            Ok(())
+        }
+    };
+}
+
+pub fn create_program_runtime_environment_v1<'a, 'ix_data>(
+    feature_set: &SVMFeatureSet,
+    compute_budget: &SVMTransactionExecutionBudget,
+    reject_deployment_of_broken_elfs: bool,
+    debugging_features: bool,
+) -> Result<BuiltinProgram<InvokeContext<'a, 'ix_data>>, Error> {
+    let enable_alt_bn128_syscall = feature_set.enable_alt_bn128_syscall;
+    let enable_alt_bn128_compression_syscall = feature_set.enable_alt_bn128_compression_syscall;
+    let enable_big_mod_exp_syscall = feature_set.enable_big_mod_exp_syscall;
+    let blake3_syscall_enabled = feature_set.blake3_syscall_enabled;
+    let curve25519_syscall_enabled = feature_set.curve25519_syscall_enabled;
+    let disable_fees_sysvar = feature_set.disable_fees_sysvar;
+    let disable_deploy_of_alloc_free_syscall =
+        reject_deployment_of_broken_elfs && feature_set.disable_deploy_of_alloc_free_syscall;
+    let last_restart_slot_syscall_enabled = feature_set.last_restart_slot_sysvar;
+    let enable_poseidon_syscall = feature_set.enable_poseidon_syscall;
+    let remaining_compute_units_syscall_enabled =
+        feature_set.remaining_compute_units_syscall_enabled;
+    let get_sysvar_syscall_enabled = feature_set.get_sysvar_syscall_enabled;
+    let enable_get_epoch_stake_syscall = feature_set.enable_get_epoch_stake_syscall;
+    let min_sbpf_version =
+        if !feature_set.disable_sbpf_v0_execution || feature_set.reenable_sbpf_v0_execution {
+            SBPFVersion::V0
+        } else {
+            SBPFVersion::V3
+        };
+    let max_sbpf_version = if feature_set.enable_sbpf_v3_deployment_and_execution {
+        SBPFVersion::V3
+    } else if feature_set.enable_sbpf_v2_deployment_and_execution {
+        SBPFVersion::V2
+    } else if feature_set.enable_sbpf_v1_deployment_and_execution {
+        SBPFVersion::V1
+    } else {
+        SBPFVersion::V0
+    };
+    debug_assert!(min_sbpf_version <= max_sbpf_version);
+
+    let config = Config {
+        max_call_depth: compute_budget.max_call_depth,
+        stack_frame_size: compute_budget.stack_frame_size,
+        enable_address_translation: true,
+        enable_stack_frame_gaps: true,
+        instruction_meter_checkpoint_distance: 10000,
+        enable_instruction_meter: true,
+        enable_register_tracing: debugging_features,
+        enable_symbol_and_section_labels: debugging_features,
+        reject_broken_elfs: reject_deployment_of_broken_elfs,
+        noop_instruction_rate: 256,
+        sanitize_user_provided_values: true,
+        enabled_sbpf_versions: min_sbpf_version..=max_sbpf_version,
+        optimize_rodata: false,
+        aligned_memory_mapping: !feature_set.stricter_abi_and_runtime_constraints,
+        allow_memory_region_zero: feature_set.enable_sbpf_v3_deployment_and_execution,
+        // Warning, do not use `Config::default()` so that configuration here is explicit.
+    };
+    let mut result = BuiltinProgram::new_loader(config);
+
+    // Abort
+    result.register_function("abort", SyscallAbort::vm)?;
+
+    // Panic
+    result.register_function("sol_panic_", SyscallPanic::vm)?;
+
+    // Logging
+    result.register_function("sol_log_", SyscallLog::vm)?;
+    result.register_function("sol_log_64_", SyscallLogU64::vm)?;
+    result.register_function("sol_log_pubkey", SyscallLogPubkey::vm)?;
+    result.register_function("sol_log_compute_units_", SyscallLogBpfComputeUnits::vm)?;
+
+    // Program defined addresses (PDA)
+    result.register_function(
+        "sol_create_program_address",
+        SyscallCreateProgramAddress::vm,
+    )?;
+    result.register_function(
+        "sol_try_find_program_address",
+        SyscallTryFindProgramAddress::vm,
+    )?;
+
+    // Sha256
+    result.register_function("sol_sha256", SyscallHash::vm::<Sha256Hasher>)?;
+
+    // Keccak256
+    result.register_function("sol_keccak256", SyscallHash::vm::<Keccak256Hasher>)?;
+
+    // Secp256k1 Recover
+    result.register_function("sol_secp256k1_recover", SyscallSecp256k1Recover::vm)?;
+
+    // Blake3
+    register_feature_gated_function!(
+        result,
+        blake3_syscall_enabled,
+        "sol_blake3",
+        SyscallHash::vm::<Blake3Hasher>,
+    )?;
+
+    // Elliptic Curve Operations
+    register_feature_gated_function!(
+        result,
+        curve25519_syscall_enabled,
+        "sol_curve_validate_point",
+        SyscallCurvePointValidation::vm,
+    )?;
+    register_feature_gated_function!(
+        result,
+        curve25519_syscall_enabled,
+        "sol_curve_group_op",
+        SyscallCurveGroupOps::vm,
+    )?;
+    register_feature_gated_function!(
+        result,
+        curve25519_syscall_enabled,
+        "sol_curve_multiscalar_mul",
+        SyscallCurveMultiscalarMultiplication::vm,
+    )?;
+
+    // Sysvars
+    result.register_function("sol_get_clock_sysvar", SyscallGetClockSysvar::vm)?;
+    result.register_function(
+        "sol_get_epoch_schedule_sysvar",
+        SyscallGetEpochScheduleSysvar::vm,
+    )?;
+    register_feature_gated_function!(
+        result,
+        !disable_fees_sysvar,
+        "sol_get_fees_sysvar",
+        SyscallGetFeesSysvar::vm,
+    )?;
+    result.register_function("sol_get_rent_sysvar", SyscallGetRentSysvar::vm)?;
+
+    register_feature_gated_function!(
+        result,
+        last_restart_slot_syscall_enabled,
+        "sol_get_last_restart_slot",
+        SyscallGetLastRestartSlotSysvar::vm,
+    )?;
+
+    result.register_function(
+        "sol_get_epoch_rewards_sysvar",
+        SyscallGetEpochRewardsSysvar::vm,
+    )?;
+
+    // Memory ops
+    result.register_function("sol_memcpy_", SyscallMemcpy::vm)?;
+    result.register_function("sol_memmove_", SyscallMemmove::vm)?;
+    result.register_function("sol_memset_", SyscallMemset::vm)?;
+    result.register_function("sol_memcmp_", SyscallMemcmp::vm)?;
+
+    // Processed sibling instructions
+    result.register_function(
+        "sol_get_processed_sibling_instruction",
+        SyscallGetProcessedSiblingInstruction::vm,
+    )?;
+
+    // Stack height
+    result.register_function("sol_get_stack_height", SyscallGetStackHeight::vm)?;
+
+    // Return data
+    result.register_function("sol_set_return_data", SyscallSetReturnData::vm)?;
+    result.register_function("sol_get_return_data", SyscallGetReturnData::vm)?;
+
+    // Cross-program invocation
+    result.register_function("sol_invoke_signed_c", SyscallInvokeSignedC::vm)?;
+    result.register_function("sol_invoke_signed_rust", SyscallInvokeSignedRust::vm)?;
+
+    // Memory allocator
+    register_feature_gated_function!(
+        result,
+        !disable_deploy_of_alloc_free_syscall,
+        "sol_alloc_free_",
+        SyscallAllocFree::vm,
+    )?;
+
+    // Alt_bn128
+    register_feature_gated_function!(
+        result,
+        enable_alt_bn128_syscall,
+        "sol_alt_bn128_group_op",
+        SyscallAltBn128::vm,
+    )?;
+
+    // Big_mod_exp
+    register_feature_gated_function!(
+        result,
+        enable_big_mod_exp_syscall,
+        "sol_big_mod_exp",
+        SyscallBigModExp::vm,
+    )?;
+
+    // Poseidon
+    register_feature_gated_function!(
+        result,
+        enable_poseidon_syscall,
+        "sol_poseidon",
+        SyscallPoseidon::vm,
+    )?;
+
+    // Accessing remaining compute units
+    register_feature_gated_function!(
+        result,
+        remaining_compute_units_syscall_enabled,
+        "sol_remaining_compute_units",
+        SyscallRemainingComputeUnits::vm
+    )?;
+
+    // Alt_bn128_compression
+    register_feature_gated_function!(
+        result,
+        enable_alt_bn128_compression_syscall,
+        "sol_alt_bn128_compression",
+        SyscallAltBn128Compression::vm,
+    )?;
+
+    // Sysvar getter
+    register_feature_gated_function!(
+        result,
+        get_sysvar_syscall_enabled,
+        "sol_get_sysvar",
+        SyscallGetSysvar::vm,
+    )?;
+
+    // Get Epoch Stake
+    register_feature_gated_function!(
+        result,
+        enable_get_epoch_stake_syscall,
+        "sol_get_epoch_stake",
+        SyscallGetEpochStake::vm,
+    )?;
+
+    // Log data
+    result.register_function("sol_log_data", SyscallLogData::vm)?;
+
+    Ok(result)
+}
+
+pub fn create_program_runtime_environment_v2<'a, 'ix_data>(
+    compute_budget: &SVMTransactionExecutionBudget,
+    debugging_features: bool,
+) -> BuiltinProgram<InvokeContext<'a, 'ix_data>> {
+    let config = Config {
+        max_call_depth: compute_budget.max_call_depth,
+        stack_frame_size: compute_budget.stack_frame_size,
+        enable_address_translation: true, // To be deactivated once we have BTF inference and verification
+        enable_stack_frame_gaps: false,
+        instruction_meter_checkpoint_distance: 10000,
+        enable_instruction_meter: true,
+        enable_register_tracing: debugging_features,
+        enable_symbol_and_section_labels: debugging_features,
+        reject_broken_elfs: true,
+        noop_instruction_rate: 256,
+        sanitize_user_provided_values: true,
+        enabled_sbpf_versions: SBPFVersion::Reserved..=SBPFVersion::Reserved,
+        optimize_rodata: true,
+        aligned_memory_mapping: true,
+        allow_memory_region_zero: true,
+        // Warning, do not use `Config::default()` so that configuration here is explicit.
+    };
+    BuiltinProgram::new_loader(config)
+}
+
+fn translate_type<'a, T>(
+    memory_mapping: &'a MemoryMapping,
+    vm_addr: u64,
+    check_aligned: bool,
+) -> Result<&'a T, Error> {
+    translate_type_inner!(memory_mapping, AccessType::Load, vm_addr, T, check_aligned)
+        .map(|value| &*value)
+}
+fn translate_slice<'a, T>(
+    memory_mapping: &'a MemoryMapping,
+    vm_addr: u64,
+    len: u64,
+    check_aligned: bool,
+) -> Result<&'a [T], Error> {
+    translate_slice_inner!(
+        memory_mapping,
+        AccessType::Load,
+        vm_addr,
+        len,
+        T,
+        check_aligned,
+    )
+    .map(|value| &*value)
+}
+
+/// Take a virtual pointer to a string (points to SBF VM memory space), translate it
+/// pass it to a user-defined work function
+fn translate_string_and_do(
+    memory_mapping: &MemoryMapping,
+    addr: u64,
+    len: u64,
+    check_aligned: bool,
+    work: &mut dyn FnMut(&str) -> Result<u64, Error>,
+) -> Result<u64, Error> {
+    let buf = translate_slice::<u8>(memory_mapping, addr, len, check_aligned)?;
+    match from_utf8(buf) {
+        Ok(message) => work(message),
+        Err(err) => Err(SyscallError::InvalidString(err, buf.to_vec()).into()),
+    }
+}
+
+// Do not use this directly
+fn translate_type_mut<'a, T>(
+    memory_mapping: &'a MemoryMapping,
+    vm_addr: u64,
+    check_aligned: bool,
+) -> Result<&'a mut T, Error> {
+    translate_type_inner!(memory_mapping, AccessType::Store, vm_addr, T, check_aligned)
+}
+// Do not use this directly
+fn translate_slice_mut<'a, T>(
+    memory_mapping: &'a MemoryMapping,
+    vm_addr: u64,
+    len: u64,
+    check_aligned: bool,
+) -> Result<&'a mut [T], Error> {
+    translate_slice_inner!(
+        memory_mapping,
+        AccessType::Store,
+        vm_addr,
+        len,
+        T,
+        check_aligned,
+    )
+}
+
+fn touch_type_mut<T>(memory_mapping: &mut MemoryMapping, vm_addr: u64) -> Result<(), Error> {
+    translate_inner!(
+        memory_mapping,
+        map_with_access_violation_handler,
+        AccessType::Store,
+        vm_addr,
+        size_of::<T>() as u64,
+    )
+    .map(|_| ())
+}
+fn touch_slice_mut<T>(
+    memory_mapping: &mut MemoryMapping,
+    vm_addr: u64,
+    element_count: u64,
+) -> Result<(), Error> {
+    if element_count == 0 {
+        return Ok(());
+    }
+    translate_inner!(
+        memory_mapping,
+        map_with_access_violation_handler,
+        AccessType::Store,
+        vm_addr,
+        element_count.saturating_mul(size_of::<T>() as u64),
+    )
+    .map(|_| ())
+}
+
+// No other translated references can be live when calling this.
+// Meaning it should generally be at the beginning or end of a syscall and
+// it should only be called once with all translations passed in one call.
+#[macro_export]
+macro_rules! translate_mut {
+    (internal, $memory_mapping:expr, &mut [$T:ty], $vm_addr_and_element_count:expr) => {
+        touch_slice_mut::<$T>(
+            $memory_mapping,
+            $vm_addr_and_element_count.0,
+            $vm_addr_and_element_count.1,
+        )?
+    };
+    (internal, $memory_mapping:expr, &mut $T:ty, $vm_addr:expr) => {
+        touch_type_mut::<$T>(
+            $memory_mapping,
+            $vm_addr,
+        )?
+    };
+    (internal, $memory_mapping:expr, $check_aligned:expr, &mut [$T:ty], $vm_addr_and_element_count:expr) => {{
+        let slice = translate_slice_mut::<$T>(
+            $memory_mapping,
+            $vm_addr_and_element_count.0,
+            $vm_addr_and_element_count.1,
+            $check_aligned,
+        )?;
+        let host_addr = slice.as_ptr() as usize;
+        (slice, host_addr, std::mem::size_of::<$T>().saturating_mul($vm_addr_and_element_count.1 as usize))
+    }};
+    (internal, $memory_mapping:expr, $check_aligned:expr, &mut $T:ty, $vm_addr:expr) => {{
+        let reference = translate_type_mut::<$T>(
+            $memory_mapping,
+            $vm_addr,
+            $check_aligned,
+        )?;
+        let host_addr = reference as *const _ as usize;
+        (reference, host_addr, std::mem::size_of::<$T>())
+    }};
+    ($memory_mapping:expr, $check_aligned:expr, $(let $binding:ident : &mut $T:tt = map($vm_addr:expr $(, $element_count:expr)?) $try:tt;)+) => {
+        // This ensures that all the parameters are collected first so that if they depend on previous translations
+        $(let $binding = ($vm_addr $(, $element_count)?);)+
+        // they are not invalidated by the following translations here:
+        $(translate_mut!(internal, $memory_mapping, &mut $T, $binding);)+
+        $(let $binding = translate_mut!(internal, $memory_mapping, $check_aligned, &mut $T, $binding);)+
+        let host_ranges = [
+            $(($binding.1, $binding.2),)+
+        ];
+        for (index, range_a) in host_ranges.get(..host_ranges.len().saturating_sub(1)).unwrap().iter().enumerate() {
+            for range_b in host_ranges.get(index.saturating_add(1)..).unwrap().iter() {
+                if !is_nonoverlapping(range_a.0, range_a.1, range_b.0, range_b.1) {
+                    return Err(SyscallError::CopyOverlapping.into());
+                }
+            }
+        }
+        $(let $binding = $binding.0;)+
+    };
+}
+
+declare_builtin_function!(
+    /// Abort syscall functions, called when the SBF program calls `abort()`
+    /// LLVM will insert calls to `abort()` if it detects an untenable situation,
+    /// `abort()` is not intended to be called explicitly by the program.
+    /// Causes the SBF program to be halted immediately
+    SyscallAbort,
+    fn rust(
+        _invoke_context: &mut InvokeContext,
+        _arg1: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        _memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        Err(SyscallError::Abort.into())
+    }
+);
+
+declare_builtin_function!(
+    /// Panic syscall function, called when the SBF program calls 'sol_panic_()`
+    /// Causes the SBF program to be halted immediately
+    SyscallPanic,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        file: u64,
+        len: u64,
+        line: u64,
+        column: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        consume_compute_meter(invoke_context, len)?;
+
+        translate_string_and_do(
+            memory_mapping,
+            file,
+            len,
+            invoke_context.get_check_aligned(),
+            &mut |string: &str| Err(SyscallError::Panic(string.to_string(), line, column).into()),
+        )
+    }
+);
+
+declare_builtin_function!(
+    /// Dynamic memory allocation syscall called when the SBF program calls
+    /// `sol_alloc_free_()`.  The allocator is expected to allocate/free
+    /// from/to a given chunk of memory and enforce size restrictions.  The
+    /// memory chunk is given to the allocator during allocator creation and
+    /// information about that memory (start address and size) is passed
+    /// to the VM to use for enforcement.
+    SyscallAllocFree,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        size: u64,
+        free_addr: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        _memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let align = if invoke_context.get_check_aligned() {
+            BPF_ALIGN_OF_U128
+        } else {
+            align_of::<u8>()
+        };
+        let Ok(layout) = Layout::from_size_align(size as usize, align) else {
+            return Ok(0);
+        };
+        let allocator = &mut invoke_context.get_syscall_context_mut()?.allocator;
+        if free_addr == 0 {
+            match allocator.alloc(layout) {
+                Ok(addr) => Ok(addr),
+                Err(_) => Ok(0),
+            }
+        } else {
+            // Unimplemented
+            Ok(0)
+        }
+    }
+);
+
+fn translate_and_check_program_address_inputs<'a>(
+    seeds_addr: u64,
+    seeds_len: u64,
+    program_id_addr: u64,
+    memory_mapping: &'a mut MemoryMapping,
+    check_aligned: bool,
+) -> Result<(Vec<&'a [u8]>, &'a Pubkey), Error> {
+    let untranslated_seeds =
+        translate_slice::<VmSlice<u8>>(memory_mapping, seeds_addr, seeds_len, check_aligned)?;
+    if untranslated_seeds.len() > MAX_SEEDS {
+        return Err(SyscallError::BadSeeds(PubkeyError::MaxSeedLengthExceeded).into());
+    }
+    let seeds = untranslated_seeds
+        .iter()
+        .map(|untranslated_seed| {
+            if untranslated_seed.len() > MAX_SEED_LEN as u64 {
+                return Err(SyscallError::BadSeeds(PubkeyError::MaxSeedLengthExceeded).into());
+            }
+            translate_vm_slice(untranslated_seed, memory_mapping, check_aligned)
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+    let program_id = translate_type::<Pubkey>(memory_mapping, program_id_addr, check_aligned)?;
+    Ok((seeds, program_id))
+}
+
+declare_builtin_function!(
+    /// Create a program address
+    SyscallCreateProgramAddress,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        seeds_addr: u64,
+        seeds_len: u64,
+        program_id_addr: u64,
+        address_addr: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let cost = invoke_context
+            .get_execution_cost()
+            .create_program_address_units;
+        consume_compute_meter(invoke_context, cost)?;
+
+        let (seeds, program_id) = translate_and_check_program_address_inputs(
+            seeds_addr,
+            seeds_len,
+            program_id_addr,
+            memory_mapping,
+            invoke_context.get_check_aligned(),
+        )?;
+
+        let Ok(new_address) = Pubkey::create_program_address(&seeds, program_id) else {
+            return Ok(1);
+        };
+        translate_mut!(
+            memory_mapping,
+            invoke_context.get_check_aligned(),
+            let address: &mut [u8] = map(address_addr, std::mem::size_of::<Pubkey>() as u64)?;
+        );
+        address.copy_from_slice(new_address.as_ref());
+        Ok(0)
+    }
+);
+
+declare_builtin_function!(
+    /// Create a program address
+    SyscallTryFindProgramAddress,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        seeds_addr: u64,
+        seeds_len: u64,
+        program_id_addr: u64,
+        address_addr: u64,
+        bump_seed_addr: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let cost = invoke_context
+            .get_execution_cost()
+            .create_program_address_units;
+        consume_compute_meter(invoke_context, cost)?;
+
+        let (seeds, program_id) = translate_and_check_program_address_inputs(
+            seeds_addr,
+            seeds_len,
+            program_id_addr,
+            memory_mapping,
+            invoke_context.get_check_aligned(),
+        )?;
+
+        let mut bump_seed = [u8::MAX];
+        for _ in 0..u8::MAX {
+            {
+                let mut seeds_with_bump = seeds.to_vec();
+                seeds_with_bump.push(&bump_seed);
+
+                if let Ok(new_address) =
+                    Pubkey::create_program_address(&seeds_with_bump, program_id)
+                {
+                    translate_mut!(
+                        memory_mapping,
+                        invoke_context.get_check_aligned(),
+                        let bump_seed_ref: &mut u8 = map(bump_seed_addr)?;
+                        let address: &mut [u8] = map(address_addr, std::mem::size_of::<Pubkey>() as u64)?;
+                    );
+                    *bump_seed_ref = bump_seed[0];
+                    address.copy_from_slice(new_address.as_ref());
+                    return Ok(0);
+                }
+            }
+            bump_seed[0] = bump_seed[0].saturating_sub(1);
+            consume_compute_meter(invoke_context, cost)?;
+        }
+        Ok(1)
+    }
+);
+
+declare_builtin_function!(
+    /// secp256k1_recover
+    SyscallSecp256k1Recover,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        hash_addr: u64,
+        recovery_id_val: u64,
+        signature_addr: u64,
+        result_addr: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let cost = invoke_context.get_execution_cost().secp256k1_recover_cost;
+        consume_compute_meter(invoke_context, cost)?;
+
+        translate_mut!(
+            memory_mapping,
+            invoke_context.get_check_aligned(),
+            let secp256k1_recover_result: &mut [u8] = map(result_addr, SECP256K1_PUBLIC_KEY_LENGTH as u64)?;
+        );
+        let hash = translate_slice::<u8>(
+            memory_mapping,
+            hash_addr,
+            keccak::HASH_BYTES as u64,
+            invoke_context.get_check_aligned(),
+        )?;
+        let signature = translate_slice::<u8>(
+            memory_mapping,
+            signature_addr,
+            SECP256K1_SIGNATURE_LENGTH as u64,
+            invoke_context.get_check_aligned(),
+        )?;
+
+        let Ok(message) = libsecp256k1::Message::parse_slice(hash) else {
+            return Ok(Secp256k1RecoverError::InvalidHash.into());
+        };
+        let Ok(adjusted_recover_id_val) = recovery_id_val.try_into() else {
+            return Ok(Secp256k1RecoverError::InvalidRecoveryId.into());
+        };
+        let Ok(recovery_id) = libsecp256k1::RecoveryId::parse(adjusted_recover_id_val) else {
+            return Ok(Secp256k1RecoverError::InvalidRecoveryId.into());
+        };
+        let Ok(signature) = libsecp256k1::Signature::parse_standard_slice(signature) else {
+            return Ok(Secp256k1RecoverError::InvalidSignature.into());
+        };
+
+        let public_key = match libsecp256k1::recover(&message, &signature, &recovery_id) {
+            Ok(key) => key.serialize(),
+            Err(_) => {
+                return Ok(Secp256k1RecoverError::InvalidSignature.into());
+            }
+        };
+
+        secp256k1_recover_result.copy_from_slice(&public_key[1..65]);
+        Ok(SUCCESS)
+    }
+);
+
+declare_builtin_function!(
+    // Elliptic Curve Point Validation
+    //
+    // Currently, only curve25519 Edwards and Ristretto representations are supported
+    SyscallCurvePointValidation,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        curve_id: u64,
+        point_addr: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        use solana_curve25519::{curve_syscall_traits::*, edwards, ristretto};
+        match curve_id {
+            CURVE25519_EDWARDS => {
+                let cost = invoke_context
+                    .get_execution_cost()
+                    .curve25519_edwards_validate_point_cost;
+                consume_compute_meter(invoke_context, cost)?;
+
+                let point = translate_type::<edwards::PodEdwardsPoint>(
+                    memory_mapping,
+                    point_addr,
+                    invoke_context.get_check_aligned(),
+                )?;
+
+                if edwards::validate_edwards(point) {
+                    Ok(0)
+                } else {
+                    Ok(1)
+                }
+            }
+            CURVE25519_RISTRETTO => {
+                let cost = invoke_context
+                    .get_execution_cost()
+                    .curve25519_ristretto_validate_point_cost;
+                consume_compute_meter(invoke_context, cost)?;
+
+                let point = translate_type::<ristretto::PodRistrettoPoint>(
+                    memory_mapping,
+                    point_addr,
+                    invoke_context.get_check_aligned(),
+                )?;
+
+                if ristretto::validate_ristretto(point) {
+                    Ok(0)
+                } else {
+                    Ok(1)
+                }
+            }
+            _ => {
+                if invoke_context.get_feature_set().abort_on_invalid_curve {
+                    Err(SyscallError::InvalidAttribute.into())
+                } else {
+                    Ok(1)
+                }
+            }
+        }
+    }
+);
+
+declare_builtin_function!(
+    // Elliptic Curve Group Operations
+    //
+    // Currently, only curve25519 Edwards and Ristretto representations are supported
+    SyscallCurveGroupOps,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        curve_id: u64,
+        group_op: u64,
+        left_input_addr: u64,
+        right_input_addr: u64,
+        result_point_addr: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        use solana_curve25519::{
+            curve_syscall_traits::*,
+            edwards::{self, PodEdwardsPoint},
+            ristretto::{self, PodRistrettoPoint},
+            scalar,
+        };
+        match curve_id {
+            CURVE25519_EDWARDS => match group_op {
+                ADD => {
+                    let cost = invoke_context
+                        .get_execution_cost()
+                        .curve25519_edwards_add_cost;
+                    consume_compute_meter(invoke_context, cost)?;
+
+                    let left_point = translate_type::<PodEdwardsPoint>(
+                        memory_mapping,
+                        left_input_addr,
+                        invoke_context.get_check_aligned(),
+                    )?;
+                    let right_point = translate_type::<PodEdwardsPoint>(
+                        memory_mapping,
+                        right_input_addr,
+                        invoke_context.get_check_aligned(),
+                    )?;
+
+                    if let Some(result_point) = edwards::add_edwards(left_point, right_point) {
+                        translate_mut!(
+                            memory_mapping,
+                            invoke_context.get_check_aligned(),
+                            let result_point_ref_mut: &mut PodEdwardsPoint = map(result_point_addr)?;
+                        );
+                        *result_point_ref_mut = result_point;
+                        Ok(0)
+                    } else {
+                        Ok(1)
+                    }
+                }
+                SUB => {
+                    let cost = invoke_context
+                        .get_execution_cost()
+                        .curve25519_edwards_subtract_cost;
+                    consume_compute_meter(invoke_context, cost)?;
+
+                    let left_point = translate_type::<PodEdwardsPoint>(
+                        memory_mapping,
+                        left_input_addr,
+                        invoke_context.get_check_aligned(),
+                    )?;
+                    let right_point = translate_type::<PodEdwardsPoint>(
+                        memory_mapping,
+                        right_input_addr,
+                        invoke_context.get_check_aligned(),
+                    )?;
+
+                    if let Some(result_point) = edwards::subtract_edwards(left_point, right_point) {
+                        translate_mut!(
+                            memory_mapping,
+                            invoke_context.get_check_aligned(),
+                            let result_point_ref_mut: &mut PodEdwardsPoint = map(result_point_addr)?;
+                        );
+                        *result_point_ref_mut = result_point;
+                        Ok(0)
+                    } else {
+                        Ok(1)
+                    }
+                }
+                MUL => {
+                    let cost = invoke_context
+                        .get_execution_cost()
+                        .curve25519_edwards_multiply_cost;
+                    consume_compute_meter(invoke_context, cost)?;
+
+                    let scalar = translate_type::<scalar::PodScalar>(
+                        memory_mapping,
+                        left_input_addr,
+                        invoke_context.get_check_aligned(),
+                    )?;
+                    let input_point = translate_type::<PodEdwardsPoint>(
+                        memory_mapping,
+                        right_input_addr,
+                        invoke_context.get_check_aligned(),
+                    )?;
+
+                    if let Some(result_point) = edwards::multiply_edwards(scalar, input_point) {
+                        translate_mut!(
+                            memory_mapping,
+                            invoke_context.get_check_aligned(),
+                            let result_point_ref_mut: &mut PodEdwardsPoint = map(result_point_addr)?;
+                        );
+                        *result_point_ref_mut = result_point;
+                        Ok(0)
+                    } else {
+                        Ok(1)
+                    }
+                }
+                _ => {
+                    if invoke_context.get_feature_set().abort_on_invalid_curve {
+                        Err(SyscallError::InvalidAttribute.into())
+                    } else {
+                        Ok(1)
+                    }
+                }
+            },
+
+            CURVE25519_RISTRETTO => match group_op {
+                ADD => {
+                    let cost = invoke_context
+                        .get_execution_cost()
+                        .curve25519_ristretto_add_cost;
+                    consume_compute_meter(invoke_context, cost)?;
+
+                    let left_point = translate_type::<PodRistrettoPoint>(
+                        memory_mapping,
+                        left_input_addr,
+                        invoke_context.get_check_aligned(),
+                    )?;
+                    let right_point = translate_type::<PodRistrettoPoint>(
+                        memory_mapping,
+                        right_input_addr,
+                        invoke_context.get_check_aligned(),
+                    )?;
+
+                    if let Some(result_point) = ristretto::add_ristretto(left_point, right_point) {
+                        translate_mut!(
+                            memory_mapping,
+                            invoke_context.get_check_aligned(),
+                            let result_point_ref_mut: &mut PodRistrettoPoint = map(result_point_addr)?;
+                        );
+                        *result_point_ref_mut = result_point;
+                        Ok(0)
+                    } else {
+                        Ok(1)
+                    }
+                }
+                SUB => {
+                    let cost = invoke_context
+                        .get_execution_cost()
+                        .curve25519_ristretto_subtract_cost;
+                    consume_compute_meter(invoke_context, cost)?;
+
+                    let left_point = translate_type::<PodRistrettoPoint>(
+                        memory_mapping,
+                        left_input_addr,
+                        invoke_context.get_check_aligned(),
+                    )?;
+                    let right_point = translate_type::<PodRistrettoPoint>(
+                        memory_mapping,
+                        right_input_addr,
+                        invoke_context.get_check_aligned(),
+                    )?;
+
+                    if let Some(result_point) =
+                        ristretto::subtract_ristretto(left_point, right_point)
+                    {
+                        translate_mut!(
+                            memory_mapping,
+                            invoke_context.get_check_aligned(),
+                            let result_point_ref_mut: &mut PodRistrettoPoint = map(result_point_addr)?;
+                        );
+                        *result_point_ref_mut = result_point;
+                        Ok(0)
+                    } else {
+                        Ok(1)
+                    }
+                }
+                MUL => {
+                    let cost = invoke_context
+                        .get_execution_cost()
+                        .curve25519_ristretto_multiply_cost;
+                    consume_compute_meter(invoke_context, cost)?;
+
+                    let scalar = translate_type::<scalar::PodScalar>(
+                        memory_mapping,
+                        left_input_addr,
+                        invoke_context.get_check_aligned(),
+                    )?;
+                    let input_point = translate_type::<PodRistrettoPoint>(
+                        memory_mapping,
+                        right_input_addr,
+                        invoke_context.get_check_aligned(),
+                    )?;
+
+                    if let Some(result_point) = ristretto::multiply_ristretto(scalar, input_point) {
+                        translate_mut!(
+                            memory_mapping,
+                            invoke_context.get_check_aligned(),
+                            let result_point_ref_mut: &mut PodRistrettoPoint = map(result_point_addr)?;
+                        );
+                        *result_point_ref_mut = result_point;
+                        Ok(0)
+                    } else {
+                        Ok(1)
+                    }
+                }
+                _ => {
+                    if invoke_context.get_feature_set().abort_on_invalid_curve {
+                        Err(SyscallError::InvalidAttribute.into())
+                    } else {
+                        Ok(1)
+                    }
+                }
+            },
+
+            _ => {
+                if invoke_context.get_feature_set().abort_on_invalid_curve {
+                    Err(SyscallError::InvalidAttribute.into())
+                } else {
+                    Ok(1)
+                }
+            }
+        }
+    }
+);
+
+declare_builtin_function!(
+    // Elliptic Curve Multiscalar Multiplication
+    //
+    // Currently, only curve25519 Edwards and Ristretto representations are supported
+    SyscallCurveMultiscalarMultiplication,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        curve_id: u64,
+        scalars_addr: u64,
+        points_addr: u64,
+        points_len: u64,
+        result_point_addr: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        use solana_curve25519::{
+            curve_syscall_traits::*,
+            edwards::{self, PodEdwardsPoint},
+            ristretto::{self, PodRistrettoPoint},
+            scalar,
+        };
+
+        if points_len > 512 {
+            return Err(Box::new(SyscallError::InvalidLength));
+        }
+
+        match curve_id {
+            CURVE25519_EDWARDS => {
+                let cost = invoke_context
+                    .get_execution_cost()
+                    .curve25519_edwards_msm_base_cost
+                    .saturating_add(
+                        invoke_context
+                            .get_execution_cost()
+                            .curve25519_edwards_msm_incremental_cost
+                            .saturating_mul(points_len.saturating_sub(1)),
+                    );
+                consume_compute_meter(invoke_context, cost)?;
+
+                let scalars = translate_slice::<scalar::PodScalar>(
+                    memory_mapping,
+                    scalars_addr,
+                    points_len,
+                    invoke_context.get_check_aligned(),
+                )?;
+
+                let points = translate_slice::<PodEdwardsPoint>(
+                    memory_mapping,
+                    points_addr,
+                    points_len,
+                    invoke_context.get_check_aligned(),
+                )?;
+
+                if let Some(result_point) = edwards::multiscalar_multiply_edwards(scalars, points) {
+                    translate_mut!(
+                        memory_mapping,
+                        invoke_context.get_check_aligned(),
+                        let result_point_ref_mut: &mut PodEdwardsPoint = map(result_point_addr)?;
+                    );
+                    *result_point_ref_mut = result_point;
+                    Ok(0)
+                } else {
+                    Ok(1)
+                }
+            }
+
+            CURVE25519_RISTRETTO => {
+                let cost = invoke_context
+                    .get_execution_cost()
+                    .curve25519_ristretto_msm_base_cost
+                    .saturating_add(
+                        invoke_context
+                            .get_execution_cost()
+                            .curve25519_ristretto_msm_incremental_cost
+                            .saturating_mul(points_len.saturating_sub(1)),
+                    );
+                consume_compute_meter(invoke_context, cost)?;
+
+                let scalars = translate_slice::<scalar::PodScalar>(
+                    memory_mapping,
+                    scalars_addr,
+                    points_len,
+                    invoke_context.get_check_aligned(),
+                )?;
+
+                let points = translate_slice::<PodRistrettoPoint>(
+                    memory_mapping,
+                    points_addr,
+                    points_len,
+                    invoke_context.get_check_aligned(),
+                )?;
+
+                if let Some(result_point) =
+                    ristretto::multiscalar_multiply_ristretto(scalars, points)
+                {
+                    translate_mut!(
+                        memory_mapping,
+                        invoke_context.get_check_aligned(),
+                        let result_point_ref_mut: &mut PodRistrettoPoint = map(result_point_addr)?;
+                    );
+                    *result_point_ref_mut = result_point;
+                    Ok(0)
+                } else {
+                    Ok(1)
+                }
+            }
+
+            _ => {
+                if invoke_context.get_feature_set().abort_on_invalid_curve {
+                    Err(SyscallError::InvalidAttribute.into())
+                } else {
+                    Ok(1)
+                }
+            }
+        }
+    }
+);
+
+declare_builtin_function!(
+    /// Set return data
+    SyscallSetReturnData,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        addr: u64,
+        len: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let execution_cost = invoke_context.get_execution_cost();
+
+        let cost = len
+            .checked_div(execution_cost.cpi_bytes_per_unit)
+            .unwrap_or(u64::MAX)
+            .saturating_add(execution_cost.syscall_base_cost);
+        consume_compute_meter(invoke_context, cost)?;
+
+        if len > MAX_RETURN_DATA as u64 {
+            return Err(SyscallError::ReturnDataTooLarge(len, MAX_RETURN_DATA as u64).into());
+        }
+
+        let return_data = if len == 0 {
+            Vec::new()
+        } else {
+            translate_slice::<u8>(
+                memory_mapping,
+                addr,
+                len,
+                invoke_context.get_check_aligned(),
+            )?
+            .to_vec()
+        };
+        let transaction_context = &mut invoke_context.transaction_context;
+        let program_id = *transaction_context
+            .get_current_instruction_context()
+            .and_then(|instruction_context| {
+                instruction_context.get_program_key()
+            })?;
+
+        transaction_context.set_return_data(program_id, return_data)?;
+
+        Ok(0)
+    }
+);
+
+declare_builtin_function!(
+    /// Get return data
+    SyscallGetReturnData,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        return_data_addr: u64,
+        length: u64,
+        program_id_addr: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let execution_cost = invoke_context.get_execution_cost();
+
+        consume_compute_meter(invoke_context, execution_cost.syscall_base_cost)?;
+
+        let (program_id, return_data) = invoke_context.transaction_context.get_return_data();
+        let length = length.min(return_data.len() as u64);
+        if length != 0 {
+            let cost = length
+                .saturating_add(size_of::<Pubkey>() as u64)
+                .checked_div(execution_cost.cpi_bytes_per_unit)
+                .unwrap_or(u64::MAX);
+            consume_compute_meter(invoke_context, cost)?;
+
+            translate_mut!(
+                memory_mapping,
+                invoke_context.get_check_aligned(),
+                let return_data_result: &mut [u8] = map(return_data_addr, length)?;
+                let program_id_result: &mut Pubkey = map(program_id_addr)?;
+            );
+
+            let to_slice = return_data_result;
+            let from_slice = return_data
+                .get(..length as usize)
+                .ok_or(SyscallError::InvokeContextBorrowFailed)?;
+            if to_slice.len() != from_slice.len() {
+                return Err(SyscallError::InvalidLength.into());
+            }
+            to_slice.copy_from_slice(from_slice);
+            *program_id_result = *program_id;
+        }
+
+        // Return the actual length, rather the length returned
+        Ok(return_data.len() as u64)
+    }
+);
+
+declare_builtin_function!(
+    /// Get a processed sigling instruction
+    SyscallGetProcessedSiblingInstruction,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        index: u64,
+        meta_addr: u64,
+        program_id_addr: u64,
+        data_addr: u64,
+        accounts_addr: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let execution_cost = invoke_context.get_execution_cost();
+
+        consume_compute_meter(invoke_context, execution_cost.syscall_base_cost)?;
+
+        // Reverse iterate through the instruction trace,
+        // ignoring anything except instructions on the same level
+        let stack_height = invoke_context.get_stack_height();
+        let instruction_trace_length = invoke_context
+            .transaction_context
+            .get_instruction_trace_length();
+        let mut reverse_index_at_stack_height = 0;
+        let mut found_instruction_context = None;
+        for index_in_trace in (0..instruction_trace_length).rev() {
+            let instruction_context = invoke_context
+                .transaction_context
+                .get_instruction_context_at_index_in_trace(index_in_trace)?;
+            if instruction_context.get_stack_height() < stack_height {
+                break;
+            }
+            if instruction_context.get_stack_height() == stack_height {
+                if index.saturating_add(1) == reverse_index_at_stack_height {
+                    found_instruction_context = Some(instruction_context);
+                    break;
+                }
+                reverse_index_at_stack_height = reverse_index_at_stack_height.saturating_add(1);
+            }
+        }
+
+        if let Some(instruction_context) = found_instruction_context {
+            translate_mut!(
+                memory_mapping,
+                invoke_context.get_check_aligned(),
+                let result_header: &mut ProcessedSiblingInstruction = map(meta_addr)?;
+            );
+
+            if result_header.data_len == (instruction_context.get_instruction_data().len() as u64)
+                && result_header.accounts_len
+                    == (instruction_context.get_number_of_instruction_accounts() as u64)
+            {
+                translate_mut!(
+                    memory_mapping,
+                    invoke_context.get_check_aligned(),
+                    let program_id: &mut Pubkey = map(program_id_addr)?;
+                    let data: &mut [u8] = map(data_addr, result_header.data_len)?;
+                    let accounts: &mut [AccountMeta] = map(accounts_addr, result_header.accounts_len)?;
+                    let result_header: &mut ProcessedSiblingInstruction = map(meta_addr)?;
+                );
+                // Marks result_header used. It had to be in translate_mut!() for the overlap checks.
+                let _ = result_header;
+
+                *program_id = *instruction_context
+                    .get_program_key()?;
+                data.clone_from_slice(instruction_context.get_instruction_data());
+                let account_metas = (0..instruction_context.get_number_of_instruction_accounts())
+                    .map(|instruction_account_index| {
+                        Ok(AccountMeta {
+                            pubkey: *instruction_context.get_key_of_instruction_account(instruction_account_index)?,
+                            is_signer: instruction_context
+                                .is_instruction_account_signer(instruction_account_index)?,
+                            is_writable: instruction_context
+                                .is_instruction_account_writable(instruction_account_index)?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, InstructionError>>()?;
+                accounts.clone_from_slice(account_metas.as_slice());
+            } else {
+                result_header.data_len = instruction_context.get_instruction_data().len() as u64;
+                result_header.accounts_len =
+                    instruction_context.get_number_of_instruction_accounts() as u64;
+            }
+            return Ok(true as u64);
+        }
+        Ok(false as u64)
+    }
+);
+
+declare_builtin_function!(
+    /// Get current call stack height
+    SyscallGetStackHeight,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        _arg1: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        _memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let execution_cost = invoke_context.get_execution_cost();
+
+        consume_compute_meter(invoke_context, execution_cost.syscall_base_cost)?;
+
+        Ok(invoke_context.get_stack_height() as u64)
+    }
+);
+
+declare_builtin_function!(
+    /// alt_bn128 group operations
+    SyscallAltBn128,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        group_op: u64,
+        input_addr: u64,
+        input_size: u64,
+        result_addr: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        use solana_bn254::versioned::{
+            alt_bn128_versioned_g1_addition, alt_bn128_versioned_g1_multiplication,
+            alt_bn128_versioned_pairing, Endianness, VersionedG1Addition,
+            VersionedG1Multiplication, VersionedPairing, ALT_BN128_ADDITION_OUTPUT_SIZE,
+            ALT_BN128_G1_ADD_BE, ALT_BN128_G1_MUL_BE, ALT_BN128_MULTIPLICATION_OUTPUT_SIZE,
+            ALT_BN128_PAIRING_BE, ALT_BN128_PAIRING_ELEMENT_SIZE,
+            ALT_BN128_PAIRING_OUTPUT_SIZE,
+        };
+
+        let execution_cost = invoke_context.get_execution_cost();
+        let (cost, output): (u64, usize) = match group_op {
+            ALT_BN128_G1_ADD_BE => (
+                execution_cost.alt_bn128_addition_cost,
+                ALT_BN128_ADDITION_OUTPUT_SIZE,
+            ),
+            ALT_BN128_G1_MUL_BE => (
+                execution_cost.alt_bn128_multiplication_cost,
+                ALT_BN128_MULTIPLICATION_OUTPUT_SIZE,
+            ),
+            ALT_BN128_PAIRING_BE => {
+                let ele_len = input_size
+                    .checked_div(ALT_BN128_PAIRING_ELEMENT_SIZE as u64)
+                    .expect("div by non-zero constant");
+                let cost = execution_cost
+                    .alt_bn128_pairing_one_pair_cost_first
+                    .saturating_add(
+                        execution_cost
+                            .alt_bn128_pairing_one_pair_cost_other
+                            .saturating_mul(ele_len.saturating_sub(1)),
+                    )
+                    .saturating_add(execution_cost.sha256_base_cost)
+                    .saturating_add(input_size)
+                    .saturating_add(ALT_BN128_PAIRING_OUTPUT_SIZE as u64);
+                (cost, ALT_BN128_PAIRING_OUTPUT_SIZE)
+            }
+            _ => {
+                return Err(SyscallError::InvalidAttribute.into());
+            }
+        };
+
+        consume_compute_meter(invoke_context, cost)?;
+
+        translate_mut!(
+            memory_mapping,
+            invoke_context.get_check_aligned(),
+            let call_result: &mut [u8] = map(result_addr, output as u64)?;
+        );
+        let input = translate_slice::<u8>(
+            memory_mapping,
+            input_addr,
+            input_size,
+            invoke_context.get_check_aligned(),
+        )?;
+
+        let result_point = match group_op {
+            ALT_BN128_G1_ADD_BE => {
+                alt_bn128_versioned_g1_addition(VersionedG1Addition::V0, input, Endianness::BE)
+            }
+            ALT_BN128_G1_MUL_BE => {
+                alt_bn128_versioned_g1_multiplication(
+                    VersionedG1Multiplication::V1,
+                    input,
+                    Endianness::BE
+                )
+            }
+            ALT_BN128_PAIRING_BE => {
+                let version = if invoke_context
+                    .get_feature_set()
+                    .fix_alt_bn128_pairing_length_check {
+                    VersionedPairing::V1
+                } else {
+                    VersionedPairing::V0
+                };
+                alt_bn128_versioned_pairing(version, input, Endianness::BE)
+            }
+            _ => {
+                return Err(SyscallError::InvalidAttribute.into());
+            }
+        };
+
+        match result_point {
+            Ok(point) => {
+                call_result.copy_from_slice(&point);
+                Ok(SUCCESS)
+            }
+            Err(_) => {
+                Ok(1)
+            }
+        }
+    }
+);
+
+declare_builtin_function!(
+    /// Big integer modular exponentiation
+    SyscallBigModExp,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        params: u64,
+        return_value: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let params = &translate_slice::<BigModExpParams>(
+            memory_mapping,
+            params,
+            1,
+            invoke_context.get_check_aligned(),
+        )?
+        .first()
+        .ok_or(SyscallError::InvalidLength)?;
+
+        if params.base_len > 512 || params.exponent_len > 512 || params.modulus_len > 512 {
+            return Err(Box::new(SyscallError::InvalidLength));
+        }
+
+        let input_len: u64 = std::cmp::max(params.base_len, params.exponent_len);
+        let input_len: u64 = std::cmp::max(input_len, params.modulus_len);
+
+        let execution_cost = invoke_context.get_execution_cost();
+        // the compute units are calculated by the quadratic equation `0.5 input_len^2 + 190`
+        consume_compute_meter(
+            invoke_context,
+            execution_cost.syscall_base_cost.saturating_add(
+                input_len
+                    .saturating_mul(input_len)
+                    .checked_div(execution_cost.big_modular_exponentiation_cost_divisor)
+                    .unwrap_or(u64::MAX)
+                    .saturating_add(execution_cost.big_modular_exponentiation_base_cost),
+            ),
+        )?;
+
+        let base = translate_slice::<u8>(
+            memory_mapping,
+            params.base as *const _ as u64,
+            params.base_len,
+            invoke_context.get_check_aligned(),
+        )?;
+
+        let exponent = translate_slice::<u8>(
+            memory_mapping,
+            params.exponent as *const _ as u64,
+            params.exponent_len,
+            invoke_context.get_check_aligned(),
+        )?;
+
+        let modulus = translate_slice::<u8>(
+            memory_mapping,
+            params.modulus as *const _ as u64,
+            params.modulus_len,
+            invoke_context.get_check_aligned(),
+        )?;
+
+        let value = big_mod_exp(base, exponent, modulus);
+
+        translate_mut!(
+            memory_mapping,
+            invoke_context.get_check_aligned(),
+            let return_value_ref_mut: &mut [u8] = map(return_value, params.modulus_len)?;
+        );
+        return_value_ref_mut.copy_from_slice(value.as_slice());
+
+        Ok(0)
+    }
+);
+
+declare_builtin_function!(
+    // Poseidon
+    SyscallPoseidon,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        parameters: u64,
+        endianness: u64,
+        vals_addr: u64,
+        vals_len: u64,
+        result_addr: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let parameters: poseidon::Parameters = parameters.try_into()?;
+        let endianness: poseidon::Endianness = endianness.try_into()?;
+
+        if vals_len > 12 {
+            ic_msg!(
+                invoke_context,
+                "Poseidon hashing {} sequences is not supported",
+                vals_len,
+            );
+            return Err(SyscallError::InvalidLength.into());
+        }
+
+        let execution_cost = invoke_context.get_execution_cost();
+        let Some(cost) = execution_cost.poseidon_cost(vals_len) else {
+            ic_msg!(
+                invoke_context,
+                "Overflow while calculating the compute cost"
+            );
+            return Err(SyscallError::ArithmeticOverflow.into());
+        };
+        consume_compute_meter(invoke_context, cost.to_owned())?;
+
+        translate_mut!(
+            memory_mapping,
+            invoke_context.get_check_aligned(),
+            let hash_result: &mut [u8] = map(result_addr, poseidon::HASH_BYTES as u64)?;
+        );
+        let inputs = translate_slice::<VmSlice<u8>>(
+            memory_mapping,
+            vals_addr,
+            vals_len,
+            invoke_context.get_check_aligned(),
+        )?;
+        let inputs = inputs
+            .iter()
+            .map(|input| {
+                translate_vm_slice(input, memory_mapping, invoke_context.get_check_aligned())
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+
+        let result = if invoke_context.get_feature_set().poseidon_enforce_padding {
+            poseidon::hashv(parameters, endianness, inputs.as_slice())
+        } else {
+            poseidon::legacy::hashv(parameters, endianness, inputs.as_slice())
+        };
+        let Ok(hash) = result else {
+            return Ok(1);
+        };
+        hash_result.copy_from_slice(&hash.to_bytes());
+
+        Ok(SUCCESS)
+    }
+);
+
+declare_builtin_function!(
+    /// Read remaining compute units
+    SyscallRemainingComputeUnits,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        _arg1: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        _memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let execution_cost = invoke_context.get_execution_cost();
+        consume_compute_meter(invoke_context, execution_cost.syscall_base_cost)?;
+
+        use solana_sbpf::vm::ContextObject;
+        Ok(invoke_context.get_remaining())
+    }
+);
+
+declare_builtin_function!(
+    /// alt_bn128 g1 and g2 compression and decompression
+    SyscallAltBn128Compression,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        op: u64,
+        input_addr: u64,
+        input_size: u64,
+        result_addr: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        use solana_bn254::{
+            prelude::{ALT_BN128_G1_POINT_SIZE, ALT_BN128_G2_POINT_SIZE},
+            compression::prelude::{
+                alt_bn128_g1_compress, alt_bn128_g1_decompress, alt_bn128_g2_compress,
+                alt_bn128_g2_decompress, ALT_BN128_G1_COMPRESS_BE, ALT_BN128_G1_DECOMPRESS_BE,
+                ALT_BN128_G2_COMPRESS_BE, ALT_BN128_G2_DECOMPRESS_BE, ALT_BN128_G1_COMPRESSED_POINT_SIZE,
+                ALT_BN128_G2_COMPRESSED_POINT_SIZE,
+            }
+        };
+        let execution_cost = invoke_context.get_execution_cost();
+        let base_cost = execution_cost.syscall_base_cost;
+        let (cost, output): (u64, usize) = match op {
+            ALT_BN128_G1_COMPRESS_BE => (
+                base_cost.saturating_add(execution_cost.alt_bn128_g1_compress),
+                ALT_BN128_G1_COMPRESSED_POINT_SIZE,
+            ),
+            ALT_BN128_G1_DECOMPRESS_BE => {
+                (base_cost.saturating_add(execution_cost.alt_bn128_g1_decompress), ALT_BN128_G1_POINT_SIZE)
+            }
+            ALT_BN128_G2_COMPRESS_BE => (
+                base_cost.saturating_add(execution_cost.alt_bn128_g2_compress),
+                ALT_BN128_G2_COMPRESSED_POINT_SIZE,
+            ),
+            ALT_BN128_G2_DECOMPRESS_BE => {
+                (base_cost.saturating_add(execution_cost.alt_bn128_g2_decompress), ALT_BN128_G2_POINT_SIZE)
+            }
+            _ => {
+                return Err(SyscallError::InvalidAttribute.into());
+            }
+        };
+
+        consume_compute_meter(invoke_context, cost)?;
+
+        translate_mut!(
+            memory_mapping,
+            invoke_context.get_check_aligned(),
+            let call_result: &mut [u8] = map(result_addr, output as u64)?;
+        );
+        let input = translate_slice::<u8>(
+            memory_mapping,
+            input_addr,
+            input_size,
+            invoke_context.get_check_aligned(),
+        )?;
+
+        match op {
+            ALT_BN128_G1_COMPRESS_BE => {
+                let Ok(result_point) = alt_bn128_g1_compress(input) else {
+                    return Ok(1);
+                };
+                call_result.copy_from_slice(&result_point);
+            }
+            ALT_BN128_G1_DECOMPRESS_BE => {
+                let Ok(result_point) = alt_bn128_g1_decompress(input) else {
+                    return Ok(1);
+                };
+                call_result.copy_from_slice(&result_point);
+            }
+            ALT_BN128_G2_COMPRESS_BE => {
+                let Ok(result_point) = alt_bn128_g2_compress(input) else {
+                    return Ok(1);
+                };
+                call_result.copy_from_slice(&result_point);
+            }
+            ALT_BN128_G2_DECOMPRESS_BE => {
+                let Ok(result_point) = alt_bn128_g2_decompress(input) else {
+                    return Ok(1);
+                };
+                call_result.copy_from_slice(&result_point);
+            }
+            _ => return Err(SyscallError::InvalidAttribute.into()),
+        }
+
+        Ok(SUCCESS)
+    }
+);
+
+declare_builtin_function!(
+    // Generic Hashing Syscall
+    SyscallHash<H: HasherImpl>,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        vals_addr: u64,
+        vals_len: u64,
+        result_addr: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let compute_budget = invoke_context.get_compute_budget();
+        let compute_cost = invoke_context.get_execution_cost();
+        let hash_base_cost = H::get_base_cost(compute_cost);
+        let hash_byte_cost = H::get_byte_cost(compute_cost);
+        let hash_max_slices = H::get_max_slices(compute_budget);
+        if hash_max_slices < vals_len {
+            ic_msg!(
+                invoke_context,
+                "{} Hashing {} sequences in one syscall is over the limit {}",
+                H::NAME,
+                vals_len,
+                hash_max_slices,
+            );
+            return Err(SyscallError::TooManySlices.into());
+        }
+
+        consume_compute_meter(invoke_context, hash_base_cost)?;
+
+        translate_mut!(
+            memory_mapping,
+            invoke_context.get_check_aligned(),
+            let hash_result: &mut [u8] = map(result_addr, std::mem::size_of::<H::Output>() as u64)?;
+        );
+        let mut hasher = H::create_hasher();
+        if vals_len > 0 {
+            let vals = translate_slice::<VmSlice<u8>>(
+                memory_mapping,
+                vals_addr,
+                vals_len,
+                invoke_context.get_check_aligned(),
+            )?;
+
+            for val in vals.iter() {
+                let bytes = translate_vm_slice(val, memory_mapping, invoke_context.get_check_aligned())?;
+                let cost = compute_cost.mem_op_base_cost.max(
+                    hash_byte_cost.saturating_mul(
+                        val.len()
+                            .checked_div(2)
+                            .expect("div by non-zero literal"),
+                    ),
+                );
+                consume_compute_meter(invoke_context, cost)?;
+                hasher.hash(bytes);
+            }
+        }
+        hash_result.copy_from_slice(hasher.result().as_ref());
+        Ok(0)
+    }
+);
+
+declare_builtin_function!(
+    // Get Epoch Stake Syscall
+    SyscallGetEpochStake,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        var_addr: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let compute_cost = invoke_context.get_execution_cost();
+
+        if var_addr == 0 {
+            // As specified by SIMD-0133: If `var_addr` is a null pointer:
+            //
+            // Compute units:
+            //
+            // ```
+            // syscall_base
+            // ```
+            let compute_units = compute_cost.syscall_base_cost;
+            consume_compute_meter(invoke_context, compute_units)?;
+            //
+            // Control flow:
+            //
+            // - The syscall aborts the virtual machine if:
+            //     - Compute budget is exceeded.
+            // - Otherwise, the syscall returns a `u64` integer representing the total active
+            //   stake on the cluster for the current epoch.
+            Ok(invoke_context.get_epoch_stake())
+        } else {
+            // As specified by SIMD-0133: If `var_addr` is _not_ a null pointer:
+            //
+            // Compute units:
+            //
+            // ```
+            // syscall_base + floor(PUBKEY_BYTES/cpi_bytes_per_unit) + mem_op_base
+            // ```
+            let compute_units = compute_cost
+                .syscall_base_cost
+                .saturating_add(
+                    (PUBKEY_BYTES as u64)
+                        .checked_div(compute_cost.cpi_bytes_per_unit)
+                        .unwrap_or(u64::MAX),
+                )
+                .saturating_add(compute_cost.mem_op_base_cost);
+            consume_compute_meter(invoke_context, compute_units)?;
+            //
+            // Control flow:
+            //
+            // - The syscall aborts the virtual machine if:
+            //     - Not all bytes in VM memory range `[vote_addr, vote_addr + 32)` are
+            //       readable.
+            //     - Compute budget is exceeded.
+            // - Otherwise, the syscall returns a `u64` integer representing the total active
+            //   stake delegated to the vote account at the provided address.
+            //   If the provided vote address corresponds to an account that is not a vote
+            //   account or does not exist, the syscall will return `0` for active stake.
+            let check_aligned = invoke_context.get_check_aligned();
+            let vote_address = translate_type::<Pubkey>(memory_mapping, var_addr, check_aligned)?;
+
+            Ok(invoke_context.get_epoch_stake_for_vote_account(vote_address))
+        }
+    }
+);
+
+#[cfg(test)]
+#[allow(clippy::arithmetic_side_effects)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+    #[allow(deprecated)]
+    use solana_sysvar::fees::Fees;
+    use {
+        super::*,
+        assert_matches::assert_matches,
+        core::slice,
+        solana_account::{create_account_shared_data_for_test, AccountSharedData},
+        solana_account_info::AccountInfo,
+        solana_clock::Clock,
+        solana_epoch_rewards::EpochRewards,
+        solana_epoch_schedule::EpochSchedule,
+        solana_fee_calculator::FeeCalculator,
+        solana_hash::HASH_BYTES,
+        solana_instruction::Instruction,
+        solana_last_restart_slot::LastRestartSlot,
+        solana_program::program::check_type_assumptions,
+        solana_program_runtime::{
+            execution_budget::MAX_HEAP_FRAME_BYTES,
+            invoke_context::{BpfAllocator, InvokeContext, SyscallContext},
+            memory::address_is_aligned,
+            with_mock_invoke_context,
+        },
+        solana_sbpf::{
+            aligned_memory::AlignedMemory,
+            ebpf::{self, HOST_ALIGN},
+            error::EbpfError,
+            memory_region::{MemoryMapping, MemoryRegion},
+            program::SBPFVersion,
+            vm::Config,
+        },
+        solana_sdk_ids::{
+            bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, native_loader, sysvar,
+        },
+        solana_sha256_hasher::hashv,
+        solana_slot_hashes::{self as slot_hashes, SlotHashes},
+        solana_stable_layout::stable_instruction::StableInstruction,
+        solana_stake_interface::stake_history::{self, StakeHistory, StakeHistoryEntry},
+        solana_sysvar_id::SysvarId,
+        solana_transaction_context::{IndexOfAccount, InstructionAccount},
+        std::{
+            hash::{DefaultHasher, Hash, Hasher},
+            mem,
+            str::FromStr,
+        },
+        test_case::test_case,
+    };
+
+    macro_rules! assert_access_violation {
+        ($result:expr, $va:expr, $len:expr) => {
+            match $result.unwrap_err().downcast_ref::<EbpfError>().unwrap() {
+                EbpfError::AccessViolation(_, va, len, _) if $va == *va && $len == *len => {}
+                EbpfError::StackAccessViolation(_, va, len, _) if $va == *va && $len == *len => {}
+                _ => panic!(),
+            }
+        };
+    }
+
+    macro_rules! prepare_mockup {
+        ($invoke_context:ident,
+         $program_key:ident,
+         $loader_key:expr $(,)?) => {
+            let $program_key = Pubkey::new_unique();
+            let transaction_accounts = vec![
+                (
+                    $loader_key,
+                    AccountSharedData::new(0, 0, &native_loader::id()),
+                ),
+                ($program_key, AccountSharedData::new(0, 0, &$loader_key)),
+            ];
+            with_mock_invoke_context!($invoke_context, transaction_context, transaction_accounts);
+            $invoke_context
+                .transaction_context
+                .configure_next_instruction_for_tests(1, vec![], vec![])
+                .unwrap();
+            $invoke_context.push().unwrap();
+        };
+    }
+
+    #[allow(dead_code)]
+    struct MockSlice {
+        vm_addr: u64,
+        len: usize,
+    }
+
+    #[test]
+    fn test_translate() {
+        const START: u64 = 0x100000000;
+        const LENGTH: u64 = 1000;
+
+        let data = vec![0u8; LENGTH as usize];
+        let addr = data.as_ptr() as u64;
+        let config = Config::default();
+        let memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_readonly(&data, START)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        let cases = vec![
+            (true, START, 0, addr),
+            (true, START, 1, addr),
+            (true, START, LENGTH, addr),
+            (true, START + 1, LENGTH - 1, addr + 1),
+            (false, START + 1, LENGTH, 0),
+            (true, START + LENGTH - 1, 1, addr + LENGTH - 1),
+            (true, START + LENGTH, 0, addr + LENGTH),
+            (false, START + LENGTH, 1, 0),
+            (false, START, LENGTH + 1, 0),
+            (false, 0, 0, 0),
+            (false, 0, 1, 0),
+            (false, START - 1, 0, 0),
+            (false, START - 1, 1, 0),
+            (true, START + LENGTH / 2, LENGTH / 2, addr + LENGTH / 2),
+        ];
+        for (ok, start, length, value) in cases {
+            if ok {
+                assert_eq!(
+                    translate_inner!(&memory_mapping, map, AccessType::Load, start, length)
+                        .unwrap(),
+                    value
+                )
+            } else {
+                assert!(
+                    translate_inner!(&memory_mapping, map, AccessType::Load, start, length)
+                        .is_err()
+                )
+            }
+        }
+    }
+
+    #[test]
+    fn test_translate_type() {
+        let config = Config::default();
+
+        // Pubkey
+        let pubkey = solana_pubkey::new_rand();
+        let memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_readonly(bytes_of(&pubkey), 0x100000000)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+        let translated_pubkey =
+            translate_type::<Pubkey>(&memory_mapping, 0x100000000, true).unwrap();
+        assert_eq!(pubkey, *translated_pubkey);
+
+        // Instruction
+        let instruction = Instruction::new_with_bincode(
+            solana_pubkey::new_rand(),
+            &"foobar",
+            vec![AccountMeta::new(solana_pubkey::new_rand(), false)],
+        );
+        let instruction = StableInstruction::from(instruction);
+        let memory_region = MemoryRegion::new_readonly(bytes_of(&instruction), 0x100000000);
+        let memory_mapping =
+            MemoryMapping::new(vec![memory_region], &config, SBPFVersion::V3).unwrap();
+        let translated_instruction =
+            translate_type::<StableInstruction>(&memory_mapping, 0x100000000, true).unwrap();
+        assert_eq!(instruction, *translated_instruction);
+
+        let memory_region = MemoryRegion::new_readonly(&bytes_of(&instruction)[..1], 0x100000000);
+        let memory_mapping =
+            MemoryMapping::new(vec![memory_region], &config, SBPFVersion::V3).unwrap();
+        assert!(translate_type::<Instruction>(&memory_mapping, 0x100000000, true).is_err());
+    }
+
+    #[test]
+    fn test_translate_slice() {
+        let config = Config::default();
+
+        // zero len
+        let good_data = vec![1u8, 2, 3, 4, 5];
+        let data: Vec<u8> = vec![];
+        assert_eq!(std::ptr::dangling::<u8>(), data.as_ptr());
+        let memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_readonly(&good_data, 0x100000000)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+        let translated_data =
+            translate_slice::<u8>(&memory_mapping, data.as_ptr() as u64, 0, true).unwrap();
+        assert_eq!(data, translated_data);
+        assert_eq!(0, translated_data.len());
+
+        // u8
+        let mut data = vec![1u8, 2, 3, 4, 5];
+        let memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_readonly(&data, 0x100000000)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+        let translated_data =
+            translate_slice::<u8>(&memory_mapping, 0x100000000, data.len() as u64, true).unwrap();
+        assert_eq!(data, translated_data);
+        *data.first_mut().unwrap() = 10;
+        assert_eq!(data, translated_data);
+        assert!(
+            translate_slice::<u8>(&memory_mapping, data.as_ptr() as u64, u64::MAX, true).is_err()
+        );
+
+        assert!(
+            translate_slice::<u8>(&memory_mapping, 0x100000000 - 1, data.len() as u64, true,)
+                .is_err()
+        );
+
+        // u64
+        let mut data = vec![1u64, 2, 3, 4, 5];
+        let memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_readonly(
+                bytes_of_slice(&data),
+                0x100000000,
+            )],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+        let translated_data =
+            translate_slice::<u64>(&memory_mapping, 0x100000000, data.len() as u64, true).unwrap();
+        assert_eq!(data, translated_data);
+        *data.first_mut().unwrap() = 10;
+        assert_eq!(data, translated_data);
+        assert!(translate_slice::<u64>(&memory_mapping, 0x100000000, u64::MAX, true).is_err());
+
+        // Pubkeys
+        let mut data = vec![solana_pubkey::new_rand(); 5];
+        let memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_readonly(
+                unsafe {
+                    slice::from_raw_parts(data.as_ptr() as *const u8, mem::size_of::<Pubkey>() * 5)
+                },
+                0x100000000,
+            )],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+        let translated_data =
+            translate_slice::<Pubkey>(&memory_mapping, 0x100000000, data.len() as u64, true)
+                .unwrap();
+        assert_eq!(data, translated_data);
+        *data.first_mut().unwrap() = solana_pubkey::new_rand(); // Both should point to same place
+        assert_eq!(data, translated_data);
+    }
+
+    #[test]
+    fn test_translate_string_and_do() {
+        let string = "Gaggablaghblagh!";
+        let config = Config::default();
+        let memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_readonly(string.as_bytes(), 0x100000000)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+        assert_eq!(
+            42,
+            translate_string_and_do(
+                &memory_mapping,
+                0x100000000,
+                string.len() as u64,
+                true,
+                &mut |string: &str| {
+                    assert_eq!(string, "Gaggablaghblagh!");
+                    Ok(42)
+                }
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Abort")]
+    fn test_syscall_abort() {
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+        let config = Config::default();
+        let mut memory_mapping = MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap();
+        let result = SyscallAbort::rust(&mut invoke_context, 0, 0, 0, 0, 0, &mut memory_mapping);
+        result.unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Panic(\"Gaggablaghblagh!\", 42, 84)")]
+    fn test_syscall_sol_panic() {
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+
+        let string = "Gaggablaghblagh!";
+        let config = Config::default();
+        let mut memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_readonly(string.as_bytes(), 0x100000000)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        invoke_context.mock_set_remaining(string.len() as u64 - 1);
+        let result = SyscallPanic::rust(
+            &mut invoke_context,
+            0x100000000,
+            string.len() as u64,
+            42,
+            84,
+            0,
+            &mut memory_mapping,
+        );
+        assert_matches!(
+            result,
+            Result::Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ComputationalBudgetExceeded
+        );
+
+        invoke_context.mock_set_remaining(string.len() as u64);
+        let result = SyscallPanic::rust(
+            &mut invoke_context,
+            0x100000000,
+            string.len() as u64,
+            42,
+            84,
+            0,
+            &mut memory_mapping,
+        );
+        result.unwrap();
+    }
+
+    #[test]
+    fn test_syscall_sol_log() {
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+
+        let string = "Gaggablaghblagh!";
+        let config = Config::default();
+        let mut memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_readonly(string.as_bytes(), 0x100000000)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        invoke_context.mock_set_remaining(400 - 1);
+        let result = SyscallLog::rust(
+            &mut invoke_context,
+            0x100000001, // AccessViolation
+            string.len() as u64,
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_access_violation!(result, 0x100000001, string.len() as u64);
+        let result = SyscallLog::rust(
+            &mut invoke_context,
+            0x100000000,
+            string.len() as u64 * 2, // AccessViolation
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_access_violation!(result, 0x100000000, string.len() as u64 * 2);
+
+        let result = SyscallLog::rust(
+            &mut invoke_context,
+            0x100000000,
+            string.len() as u64,
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        result.unwrap();
+        let result = SyscallLog::rust(
+            &mut invoke_context,
+            0x100000000,
+            string.len() as u64,
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_matches!(
+            result,
+            Result::Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ComputationalBudgetExceeded
+        );
+
+        assert_eq!(
+            invoke_context
+                .get_log_collector()
+                .unwrap()
+                .borrow()
+                .get_recorded_content(),
+            &["Program log: Gaggablaghblagh!".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_syscall_sol_log_u64() {
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+        let cost = invoke_context.get_execution_cost().log_64_units;
+
+        invoke_context.mock_set_remaining(cost);
+        let config = Config::default();
+        let mut memory_mapping = MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap();
+        let result = SyscallLogU64::rust(&mut invoke_context, 1, 2, 3, 4, 5, &mut memory_mapping);
+        result.unwrap();
+
+        assert_eq!(
+            invoke_context
+                .get_log_collector()
+                .unwrap()
+                .borrow()
+                .get_recorded_content(),
+            &["Program log: 0x1, 0x2, 0x3, 0x4, 0x5".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_syscall_sol_pubkey() {
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+        let cost = invoke_context.get_execution_cost().log_pubkey_units;
+
+        let pubkey = Pubkey::from_str("MoqiU1vryuCGQSxFKA1SZ316JdLEFFhoAu6cKUNk7dN").unwrap();
+        let config = Config::default();
+        let mut memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_readonly(bytes_of(&pubkey), 0x100000000)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        let result = SyscallLogPubkey::rust(
+            &mut invoke_context,
+            0x100000001, // AccessViolation
+            32,
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_access_violation!(result, 0x100000001, 32);
+
+        invoke_context.mock_set_remaining(1);
+        let result =
+            SyscallLogPubkey::rust(&mut invoke_context, 100, 32, 0, 0, 0, &mut memory_mapping);
+        assert_matches!(
+            result,
+            Result::Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ComputationalBudgetExceeded
+        );
+
+        invoke_context.mock_set_remaining(cost);
+        let result = SyscallLogPubkey::rust(
+            &mut invoke_context,
+            0x100000000,
+            0,
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        result.unwrap();
+
+        assert_eq!(
+            invoke_context
+                .get_log_collector()
+                .unwrap()
+                .borrow()
+                .get_recorded_content(),
+            &["Program log: MoqiU1vryuCGQSxFKA1SZ316JdLEFFhoAu6cKUNk7dN".to_string()]
+        );
+    }
+
+    macro_rules! setup_alloc_test {
+        ($invoke_context:ident, $memory_mapping:ident, $heap:ident) => {
+            prepare_mockup!($invoke_context, program_id, bpf_loader::id());
+            $invoke_context
+                .set_syscall_context(SyscallContext {
+                    allocator: BpfAllocator::new(solana_program_entrypoint::HEAP_LENGTH as u64),
+                    accounts_metadata: Vec::new(),
+                })
+                .unwrap();
+            let config = Config {
+                aligned_memory_mapping: false,
+                ..Config::default()
+            };
+            let mut $heap =
+                AlignedMemory::<{ HOST_ALIGN }>::zero_filled(MAX_HEAP_FRAME_BYTES as usize);
+            let regions = vec![MemoryRegion::new_writable(
+                $heap.as_slice_mut(),
+                ebpf::MM_HEAP_START,
+            )];
+            let mut $memory_mapping =
+                MemoryMapping::new(regions, &config, SBPFVersion::V3).unwrap();
+        };
+    }
+
+    #[test]
+    fn test_syscall_sol_alloc_free() {
+        // large alloc
+        {
+            setup_alloc_test!(invoke_context, memory_mapping, heap);
+            let result = SyscallAllocFree::rust(
+                &mut invoke_context,
+                solana_program_entrypoint::HEAP_LENGTH as u64,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            );
+            assert_ne!(result.unwrap(), 0);
+            let result = SyscallAllocFree::rust(
+                &mut invoke_context,
+                solana_program_entrypoint::HEAP_LENGTH as u64,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+            let result = SyscallAllocFree::rust(
+                &mut invoke_context,
+                u64::MAX,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+        }
+
+        // many small unaligned allocs
+        {
+            setup_alloc_test!(invoke_context, memory_mapping, heap);
+            for _ in 0..100 {
+                let result =
+                    SyscallAllocFree::rust(&mut invoke_context, 1, 0, 0, 0, 0, &mut memory_mapping);
+                assert_ne!(result.unwrap(), 0);
+            }
+            let result = SyscallAllocFree::rust(
+                &mut invoke_context,
+                solana_program_entrypoint::HEAP_LENGTH as u64,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+        }
+
+        // many small aligned allocs
+        {
+            setup_alloc_test!(invoke_context, memory_mapping, heap);
+            for _ in 0..12 {
+                let result =
+                    SyscallAllocFree::rust(&mut invoke_context, 1, 0, 0, 0, 0, &mut memory_mapping);
+                assert_ne!(result.unwrap(), 0);
+            }
+            let result = SyscallAllocFree::rust(
+                &mut invoke_context,
+                solana_program_entrypoint::HEAP_LENGTH as u64,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+        }
+
+        // aligned allocs
+
+        fn aligned<T>() {
+            setup_alloc_test!(invoke_context, memory_mapping, heap);
+            let result = SyscallAllocFree::rust(
+                &mut invoke_context,
+                size_of::<T>() as u64,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            );
+            let address = result.unwrap();
+            assert_ne!(address, 0);
+            assert!(address_is_aligned::<T>(address));
+        }
+        aligned::<u8>();
+        aligned::<u16>();
+        aligned::<u32>();
+        aligned::<u64>();
+        aligned::<u128>();
+    }
+
+    #[test]
+    fn test_syscall_sha256() {
+        let config = Config::default();
+        prepare_mockup!(invoke_context, program_id, bpf_loader_deprecated::id());
+
+        let bytes1 = "Gaggablaghblagh!";
+        let bytes2 = "flurbos";
+
+        let mock_slice1 = MockSlice {
+            vm_addr: 0x300000000,
+            len: bytes1.len(),
+        };
+        let mock_slice2 = MockSlice {
+            vm_addr: 0x400000000,
+            len: bytes2.len(),
+        };
+        let bytes_to_hash = [mock_slice1, mock_slice2];
+        let mut hash_result = [0; HASH_BYTES];
+        let ro_len = bytes_to_hash.len() as u64;
+        let ro_va = 0x100000000;
+        let rw_va = 0x200000000;
+        let mut memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(bytes_of_slice(&bytes_to_hash), ro_va),
+                MemoryRegion::new_writable(bytes_of_slice_mut(&mut hash_result), rw_va),
+                MemoryRegion::new_readonly(bytes1.as_bytes(), bytes_to_hash[0].vm_addr),
+                MemoryRegion::new_readonly(bytes2.as_bytes(), bytes_to_hash[1].vm_addr),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        invoke_context.mock_set_remaining(
+            (invoke_context.get_execution_cost().sha256_base_cost
+                + invoke_context.get_execution_cost().mem_op_base_cost.max(
+                    invoke_context
+                        .get_execution_cost()
+                        .sha256_byte_cost
+                        .saturating_mul((bytes1.len() + bytes2.len()) as u64 / 2),
+                ))
+                * 4,
+        );
+
+        let result = SyscallHash::rust::<Sha256Hasher>(
+            &mut invoke_context,
+            ro_va,
+            ro_len,
+            rw_va,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        result.unwrap();
+
+        let hash_local = hashv(&[bytes1.as_ref(), bytes2.as_ref()]).to_bytes();
+        assert_eq!(hash_result, hash_local);
+        let result = SyscallHash::rust::<Sha256Hasher>(
+            &mut invoke_context,
+            ro_va - 1, // AccessViolation
+            ro_len,
+            rw_va,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_access_violation!(result, ro_va - 1, 32);
+        let result = SyscallHash::rust::<Sha256Hasher>(
+            &mut invoke_context,
+            ro_va,
+            ro_len + 1, // AccessViolation
+            rw_va,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_access_violation!(result, ro_va, 48);
+        let result = SyscallHash::rust::<Sha256Hasher>(
+            &mut invoke_context,
+            ro_va,
+            ro_len,
+            rw_va - 1, // AccessViolation
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_access_violation!(result, rw_va - 1, HASH_BYTES as u64);
+        let result = SyscallHash::rust::<Sha256Hasher>(
+            &mut invoke_context,
+            ro_va,
+            ro_len,
+            rw_va,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_matches!(
+            result,
+            Result::Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ComputationalBudgetExceeded
+        );
+    }
+
+    #[test]
+    fn test_syscall_edwards_curve_point_validation() {
+        use solana_curve25519::curve_syscall_traits::CURVE25519_EDWARDS;
+
+        let config = Config::default();
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+
+        let valid_bytes: [u8; 32] = [
+            201, 179, 241, 122, 180, 185, 239, 50, 183, 52, 221, 0, 153, 195, 43, 18, 22, 38, 187,
+            206, 179, 192, 210, 58, 53, 45, 150, 98, 89, 17, 158, 11,
+        ];
+        let valid_bytes_va = 0x100000000;
+
+        let invalid_bytes: [u8; 32] = [
+            120, 140, 152, 233, 41, 227, 203, 27, 87, 115, 25, 251, 219, 5, 84, 148, 117, 38, 84,
+            60, 87, 144, 161, 146, 42, 34, 91, 155, 158, 189, 121, 79,
+        ];
+        let invalid_bytes_va = 0x200000000;
+
+        let mut memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(&valid_bytes, valid_bytes_va),
+                MemoryRegion::new_readonly(&invalid_bytes, invalid_bytes_va),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        invoke_context.mock_set_remaining(
+            (invoke_context
+                .get_execution_cost()
+                .curve25519_edwards_validate_point_cost)
+                * 2,
+        );
+
+        let result = SyscallCurvePointValidation::rust(
+            &mut invoke_context,
+            CURVE25519_EDWARDS,
+            valid_bytes_va,
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_eq!(0, result.unwrap());
+
+        let result = SyscallCurvePointValidation::rust(
+            &mut invoke_context,
+            CURVE25519_EDWARDS,
+            invalid_bytes_va,
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_eq!(1, result.unwrap());
+
+        let result = SyscallCurvePointValidation::rust(
+            &mut invoke_context,
+            CURVE25519_EDWARDS,
+            valid_bytes_va,
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_matches!(
+            result,
+            Result::Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ComputationalBudgetExceeded
+        );
+    }
+
+    #[test]
+    fn test_syscall_ristretto_curve_point_validation() {
+        use solana_curve25519::curve_syscall_traits::CURVE25519_RISTRETTO;
+
+        let config = Config::default();
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+
+        let valid_bytes: [u8; 32] = [
+            226, 242, 174, 10, 106, 188, 78, 113, 168, 132, 169, 97, 197, 0, 81, 95, 88, 227, 11,
+            106, 165, 130, 221, 141, 182, 166, 89, 69, 224, 141, 45, 118,
+        ];
+        let valid_bytes_va = 0x100000000;
+
+        let invalid_bytes: [u8; 32] = [
+            120, 140, 152, 233, 41, 227, 203, 27, 87, 115, 25, 251, 219, 5, 84, 148, 117, 38, 84,
+            60, 87, 144, 161, 146, 42, 34, 91, 155, 158, 189, 121, 79,
+        ];
+        let invalid_bytes_va = 0x200000000;
+
+        let mut memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(&valid_bytes, valid_bytes_va),
+                MemoryRegion::new_readonly(&invalid_bytes, invalid_bytes_va),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        invoke_context.mock_set_remaining(
+            (invoke_context
+                .get_execution_cost()
+                .curve25519_ristretto_validate_point_cost)
+                * 2,
+        );
+
+        let result = SyscallCurvePointValidation::rust(
+            &mut invoke_context,
+            CURVE25519_RISTRETTO,
+            valid_bytes_va,
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_eq!(0, result.unwrap());
+
+        let result = SyscallCurvePointValidation::rust(
+            &mut invoke_context,
+            CURVE25519_RISTRETTO,
+            invalid_bytes_va,
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_eq!(1, result.unwrap());
+
+        let result = SyscallCurvePointValidation::rust(
+            &mut invoke_context,
+            CURVE25519_RISTRETTO,
+            valid_bytes_va,
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_matches!(
+            result,
+            Result::Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ComputationalBudgetExceeded
+        );
+    }
+
+    #[test]
+    fn test_syscall_edwards_curve_group_ops() {
+        use solana_curve25519::curve_syscall_traits::{ADD, CURVE25519_EDWARDS, MUL, SUB};
+
+        let config = Config::default();
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+
+        let left_point: [u8; 32] = [
+            33, 124, 71, 170, 117, 69, 151, 247, 59, 12, 95, 125, 133, 166, 64, 5, 2, 27, 90, 27,
+            200, 167, 59, 164, 52, 54, 52, 200, 29, 13, 34, 213,
+        ];
+        let left_point_va = 0x100000000;
+        let right_point: [u8; 32] = [
+            70, 222, 137, 221, 253, 204, 71, 51, 78, 8, 124, 1, 67, 200, 102, 225, 122, 228, 111,
+            183, 129, 14, 131, 210, 212, 95, 109, 246, 55, 10, 159, 91,
+        ];
+        let right_point_va = 0x200000000;
+        let scalar: [u8; 32] = [
+            254, 198, 23, 138, 67, 243, 184, 110, 236, 115, 236, 205, 205, 215, 79, 114, 45, 250,
+            78, 137, 3, 107, 136, 237, 49, 126, 117, 223, 37, 191, 88, 6,
+        ];
+        let scalar_va = 0x300000000;
+        let invalid_point: [u8; 32] = [
+            120, 140, 152, 233, 41, 227, 203, 27, 87, 115, 25, 251, 219, 5, 84, 148, 117, 38, 84,
+            60, 87, 144, 161, 146, 42, 34, 91, 155, 158, 189, 121, 79,
+        ];
+        let invalid_point_va = 0x400000000;
+        let mut result_point: [u8; 32] = [0; 32];
+        let result_point_va = 0x500000000;
+
+        let mut memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(bytes_of_slice(&left_point), left_point_va),
+                MemoryRegion::new_readonly(bytes_of_slice(&right_point), right_point_va),
+                MemoryRegion::new_readonly(bytes_of_slice(&scalar), scalar_va),
+                MemoryRegion::new_readonly(bytes_of_slice(&invalid_point), invalid_point_va),
+                MemoryRegion::new_writable(bytes_of_slice_mut(&mut result_point), result_point_va),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        invoke_context.mock_set_remaining(
+            (invoke_context
+                .get_execution_cost()
+                .curve25519_edwards_add_cost
+                + invoke_context
+                    .get_execution_cost()
+                    .curve25519_edwards_subtract_cost
+                + invoke_context
+                    .get_execution_cost()
+                    .curve25519_edwards_multiply_cost)
+                * 2,
+        );
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            CURVE25519_EDWARDS,
+            ADD,
+            left_point_va,
+            right_point_va,
+            result_point_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        let expected_sum = [
+            7, 251, 187, 86, 186, 232, 57, 242, 193, 236, 49, 200, 90, 29, 254, 82, 46, 80, 83, 70,
+            244, 153, 23, 156, 2, 138, 207, 51, 165, 38, 200, 85,
+        ];
+        assert_eq!(expected_sum, result_point);
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            CURVE25519_EDWARDS,
+            ADD,
+            invalid_point_va,
+            right_point_va,
+            result_point_va,
+            &mut memory_mapping,
+        );
+        assert_eq!(1, result.unwrap());
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            CURVE25519_EDWARDS,
+            SUB,
+            left_point_va,
+            right_point_va,
+            result_point_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        let expected_difference = [
+            60, 87, 90, 68, 232, 25, 7, 172, 247, 120, 158, 104, 52, 127, 94, 244, 5, 79, 253, 15,
+            48, 69, 82, 134, 155, 70, 188, 81, 108, 95, 212, 9,
+        ];
+        assert_eq!(expected_difference, result_point);
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            CURVE25519_EDWARDS,
+            SUB,
+            invalid_point_va,
+            right_point_va,
+            result_point_va,
+            &mut memory_mapping,
+        );
+        assert_eq!(1, result.unwrap());
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            CURVE25519_EDWARDS,
+            MUL,
+            scalar_va,
+            right_point_va,
+            result_point_va,
+            &mut memory_mapping,
+        );
+
+        result.unwrap();
+        let expected_product = [
+            64, 150, 40, 55, 80, 49, 217, 209, 105, 229, 181, 65, 241, 68, 2, 106, 220, 234, 211,
+            71, 159, 76, 156, 114, 242, 68, 147, 31, 243, 211, 191, 124,
+        ];
+        assert_eq!(expected_product, result_point);
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            CURVE25519_EDWARDS,
+            MUL,
+            scalar_va,
+            invalid_point_va,
+            result_point_va,
+            &mut memory_mapping,
+        );
+        assert_eq!(1, result.unwrap());
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            CURVE25519_EDWARDS,
+            MUL,
+            scalar_va,
+            invalid_point_va,
+            result_point_va,
+            &mut memory_mapping,
+        );
+        assert_matches!(
+            result,
+            Result::Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ComputationalBudgetExceeded
+        );
+    }
+
+    #[test]
+    fn test_syscall_ristretto_curve_group_ops() {
+        use solana_curve25519::curve_syscall_traits::{ADD, CURVE25519_RISTRETTO, MUL, SUB};
+
+        let config = Config::default();
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+
+        let left_point: [u8; 32] = [
+            208, 165, 125, 204, 2, 100, 218, 17, 170, 194, 23, 9, 102, 156, 134, 136, 217, 190, 98,
+            34, 183, 194, 228, 153, 92, 11, 108, 103, 28, 57, 88, 15,
+        ];
+        let left_point_va = 0x100000000;
+        let right_point: [u8; 32] = [
+            208, 241, 72, 163, 73, 53, 32, 174, 54, 194, 71, 8, 70, 181, 244, 199, 93, 147, 99,
+            231, 162, 127, 25, 40, 39, 19, 140, 132, 112, 212, 145, 108,
+        ];
+        let right_point_va = 0x200000000;
+        let scalar: [u8; 32] = [
+            254, 198, 23, 138, 67, 243, 184, 110, 236, 115, 236, 205, 205, 215, 79, 114, 45, 250,
+            78, 137, 3, 107, 136, 237, 49, 126, 117, 223, 37, 191, 88, 6,
+        ];
+        let scalar_va = 0x300000000;
+        let invalid_point: [u8; 32] = [
+            120, 140, 152, 233, 41, 227, 203, 27, 87, 115, 25, 251, 219, 5, 84, 148, 117, 38, 84,
+            60, 87, 144, 161, 146, 42, 34, 91, 155, 158, 189, 121, 79,
+        ];
+        let invalid_point_va = 0x400000000;
+        let mut result_point: [u8; 32] = [0; 32];
+        let result_point_va = 0x500000000;
+
+        let mut memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(bytes_of_slice(&left_point), left_point_va),
+                MemoryRegion::new_readonly(bytes_of_slice(&right_point), right_point_va),
+                MemoryRegion::new_readonly(bytes_of_slice(&scalar), scalar_va),
+                MemoryRegion::new_readonly(bytes_of_slice(&invalid_point), invalid_point_va),
+                MemoryRegion::new_writable(bytes_of_slice_mut(&mut result_point), result_point_va),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        invoke_context.mock_set_remaining(
+            (invoke_context
+                .get_execution_cost()
+                .curve25519_ristretto_add_cost
+                + invoke_context
+                    .get_execution_cost()
+                    .curve25519_ristretto_subtract_cost
+                + invoke_context
+                    .get_execution_cost()
+                    .curve25519_ristretto_multiply_cost)
+                * 2,
+        );
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            CURVE25519_RISTRETTO,
+            ADD,
+            left_point_va,
+            right_point_va,
+            result_point_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        let expected_sum = [
+            78, 173, 9, 241, 180, 224, 31, 107, 176, 210, 144, 240, 118, 73, 70, 191, 128, 119,
+            141, 113, 125, 215, 161, 71, 49, 176, 87, 38, 180, 177, 39, 78,
+        ];
+        assert_eq!(expected_sum, result_point);
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            CURVE25519_RISTRETTO,
+            ADD,
+            invalid_point_va,
+            right_point_va,
+            result_point_va,
+            &mut memory_mapping,
+        );
+        assert_eq!(1, result.unwrap());
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            CURVE25519_RISTRETTO,
+            SUB,
+            left_point_va,
+            right_point_va,
+            result_point_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        let expected_difference = [
+            150, 72, 222, 61, 148, 79, 96, 130, 151, 176, 29, 217, 231, 211, 0, 215, 76, 86, 212,
+            146, 110, 128, 24, 151, 187, 144, 108, 233, 221, 208, 157, 52,
+        ];
+        assert_eq!(expected_difference, result_point);
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            CURVE25519_RISTRETTO,
+            SUB,
+            invalid_point_va,
+            right_point_va,
+            result_point_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(1, result.unwrap());
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            CURVE25519_RISTRETTO,
+            MUL,
+            scalar_va,
+            right_point_va,
+            result_point_va,
+            &mut memory_mapping,
+        );
+
+        result.unwrap();
+        let expected_product = [
+            4, 16, 46, 2, 53, 151, 201, 133, 117, 149, 232, 164, 119, 109, 136, 20, 153, 24, 124,
+            21, 101, 124, 80, 19, 119, 100, 77, 108, 65, 187, 228, 5,
+        ];
+        assert_eq!(expected_product, result_point);
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            CURVE25519_RISTRETTO,
+            MUL,
+            scalar_va,
+            invalid_point_va,
+            result_point_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(1, result.unwrap());
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            CURVE25519_RISTRETTO,
+            MUL,
+            scalar_va,
+            invalid_point_va,
+            result_point_va,
+            &mut memory_mapping,
+        );
+        assert_matches!(
+            result,
+            Result::Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ComputationalBudgetExceeded
+        );
+    }
+
+    #[test]
+    fn test_syscall_multiscalar_multiplication() {
+        use solana_curve25519::curve_syscall_traits::{CURVE25519_EDWARDS, CURVE25519_RISTRETTO};
+
+        let config = Config::default();
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+
+        let scalar_a: [u8; 32] = [
+            254, 198, 23, 138, 67, 243, 184, 110, 236, 115, 236, 205, 205, 215, 79, 114, 45, 250,
+            78, 137, 3, 107, 136, 237, 49, 126, 117, 223, 37, 191, 88, 6,
+        ];
+        let scalar_b: [u8; 32] = [
+            254, 198, 23, 138, 67, 243, 184, 110, 236, 115, 236, 205, 205, 215, 79, 114, 45, 250,
+            78, 137, 3, 107, 136, 237, 49, 126, 117, 223, 37, 191, 88, 6,
+        ];
+
+        let scalars = [scalar_a, scalar_b];
+        let scalars_va = 0x100000000;
+
+        let edwards_point_x: [u8; 32] = [
+            252, 31, 230, 46, 173, 95, 144, 148, 158, 157, 63, 10, 8, 68, 58, 176, 142, 192, 168,
+            53, 61, 105, 194, 166, 43, 56, 246, 236, 28, 146, 114, 133,
+        ];
+        let edwards_point_y: [u8; 32] = [
+            10, 111, 8, 236, 97, 189, 124, 69, 89, 176, 222, 39, 199, 253, 111, 11, 248, 186, 128,
+            90, 120, 128, 248, 210, 232, 183, 93, 104, 111, 150, 7, 241,
+        ];
+        let edwards_points = [edwards_point_x, edwards_point_y];
+        let edwards_points_va = 0x200000000;
+
+        let ristretto_point_x: [u8; 32] = [
+            130, 35, 97, 25, 18, 199, 33, 239, 85, 143, 119, 111, 49, 51, 224, 40, 167, 185, 240,
+            179, 25, 194, 213, 41, 14, 155, 104, 18, 181, 197, 15, 112,
+        ];
+        let ristretto_point_y: [u8; 32] = [
+            152, 156, 155, 197, 152, 232, 92, 206, 219, 159, 193, 134, 121, 128, 139, 36, 56, 191,
+            51, 143, 72, 204, 87, 76, 110, 124, 101, 96, 238, 158, 42, 108,
+        ];
+        let ristretto_points = [ristretto_point_x, ristretto_point_y];
+        let ristretto_points_va = 0x300000000;
+
+        let mut result_point: [u8; 32] = [0; 32];
+        let result_point_va = 0x400000000;
+
+        let mut memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(bytes_of_slice(&scalars), scalars_va),
+                MemoryRegion::new_readonly(bytes_of_slice(&edwards_points), edwards_points_va),
+                MemoryRegion::new_readonly(bytes_of_slice(&ristretto_points), ristretto_points_va),
+                MemoryRegion::new_writable(bytes_of_slice_mut(&mut result_point), result_point_va),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        invoke_context.mock_set_remaining(
+            invoke_context
+                .get_execution_cost()
+                .curve25519_edwards_msm_base_cost
+                + invoke_context
+                    .get_execution_cost()
+                    .curve25519_edwards_msm_incremental_cost
+                + invoke_context
+                    .get_execution_cost()
+                    .curve25519_ristretto_msm_base_cost
+                + invoke_context
+                    .get_execution_cost()
+                    .curve25519_ristretto_msm_incremental_cost,
+        );
+
+        let result = SyscallCurveMultiscalarMultiplication::rust(
+            &mut invoke_context,
+            CURVE25519_EDWARDS,
+            scalars_va,
+            edwards_points_va,
+            2,
+            result_point_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        let expected_product = [
+            30, 174, 168, 34, 160, 70, 63, 166, 236, 18, 74, 144, 185, 222, 208, 243, 5, 54, 223,
+            172, 185, 75, 244, 26, 70, 18, 248, 46, 207, 184, 235, 60,
+        ];
+        assert_eq!(expected_product, result_point);
+
+        let result = SyscallCurveMultiscalarMultiplication::rust(
+            &mut invoke_context,
+            CURVE25519_RISTRETTO,
+            scalars_va,
+            ristretto_points_va,
+            2,
+            result_point_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        let expected_product = [
+            78, 120, 86, 111, 152, 64, 146, 84, 14, 236, 77, 147, 237, 190, 251, 241, 136, 167, 21,
+            94, 84, 118, 92, 140, 120, 81, 30, 246, 173, 140, 195, 86,
+        ];
+        assert_eq!(expected_product, result_point);
+    }
+
+    #[test]
+    fn test_syscall_multiscalar_multiplication_maximum_length_exceeded() {
+        use solana_curve25519::curve_syscall_traits::{CURVE25519_EDWARDS, CURVE25519_RISTRETTO};
+
+        let config = Config::default();
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+
+        let scalar: [u8; 32] = [
+            254, 198, 23, 138, 67, 243, 184, 110, 236, 115, 236, 205, 205, 215, 79, 114, 45, 250,
+            78, 137, 3, 107, 136, 237, 49, 126, 117, 223, 37, 191, 88, 6,
+        ];
+        let scalars = [scalar; 513];
+        let scalars_va = 0x100000000;
+
+        let edwards_point: [u8; 32] = [
+            252, 31, 230, 46, 173, 95, 144, 148, 158, 157, 63, 10, 8, 68, 58, 176, 142, 192, 168,
+            53, 61, 105, 194, 166, 43, 56, 246, 236, 28, 146, 114, 133,
+        ];
+        let edwards_points = [edwards_point; 513];
+        let edwards_points_va = 0x200000000;
+
+        let ristretto_point: [u8; 32] = [
+            130, 35, 97, 25, 18, 199, 33, 239, 85, 143, 119, 111, 49, 51, 224, 40, 167, 185, 240,
+            179, 25, 194, 213, 41, 14, 155, 104, 18, 181, 197, 15, 112,
+        ];
+        let ristretto_points = [ristretto_point; 513];
+        let ristretto_points_va = 0x300000000;
+
+        let mut result_point: [u8; 32] = [0; 32];
+        let result_point_va = 0x400000000;
+
+        let mut memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(bytes_of_slice(&scalars), scalars_va),
+                MemoryRegion::new_readonly(bytes_of_slice(&edwards_points), edwards_points_va),
+                MemoryRegion::new_readonly(bytes_of_slice(&ristretto_points), ristretto_points_va),
+                MemoryRegion::new_writable(bytes_of_slice_mut(&mut result_point), result_point_va),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        // test Edwards
+        invoke_context.mock_set_remaining(500_000);
+        let result = SyscallCurveMultiscalarMultiplication::rust(
+            &mut invoke_context,
+            CURVE25519_EDWARDS,
+            scalars_va,
+            edwards_points_va,
+            512, // below maximum vector length
+            result_point_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        let expected_product = [
+            20, 146, 226, 37, 22, 61, 86, 249, 208, 40, 38, 11, 126, 101, 10, 82, 81, 77, 88, 209,
+            15, 76, 82, 251, 180, 133, 84, 243, 162, 0, 11, 145,
+        ];
+        assert_eq!(expected_product, result_point);
+
+        invoke_context.mock_set_remaining(500_000);
+        let result = SyscallCurveMultiscalarMultiplication::rust(
+            &mut invoke_context,
+            CURVE25519_EDWARDS,
+            scalars_va,
+            edwards_points_va,
+            513, // above maximum vector length
+            result_point_va,
+            &mut memory_mapping,
+        )
+        .unwrap_err()
+        .downcast::<SyscallError>()
+        .unwrap();
+
+        assert_eq!(*result, SyscallError::InvalidLength);
+
+        // test Ristretto
+        invoke_context.mock_set_remaining(500_000);
+        let result = SyscallCurveMultiscalarMultiplication::rust(
+            &mut invoke_context,
+            CURVE25519_RISTRETTO,
+            scalars_va,
+            ristretto_points_va,
+            512, // below maximum vector length
+            result_point_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        let expected_product = [
+            146, 224, 127, 193, 252, 64, 196, 181, 246, 104, 27, 116, 183, 52, 200, 239, 2, 108,
+            21, 27, 97, 44, 95, 65, 26, 218, 223, 39, 197, 132, 51, 49,
+        ];
+        assert_eq!(expected_product, result_point);
+
+        invoke_context.mock_set_remaining(500_000);
+        let result = SyscallCurveMultiscalarMultiplication::rust(
+            &mut invoke_context,
+            CURVE25519_RISTRETTO,
+            scalars_va,
+            ristretto_points_va,
+            513, // above maximum vector length
+            result_point_va,
+            &mut memory_mapping,
+        )
+        .unwrap_err()
+        .downcast::<SyscallError>()
+        .unwrap();
+
+        assert_eq!(*result, SyscallError::InvalidLength);
+    }
+
+    fn create_filled_type<T: Default>(zero_init: bool) -> T {
+        let mut val = T::default();
+        let p = &mut val as *mut _ as *mut u8;
+        for i in 0..(size_of::<T>() as isize) {
+            unsafe {
+                *p.offset(i) = if zero_init { 0 } else { i as u8 };
+            }
+        }
+        val
+    }
+
+    fn are_bytes_equal<T>(first: &T, second: &T) -> bool {
+        let p_first = first as *const _ as *const u8;
+        let p_second = second as *const _ as *const u8;
+
+        for i in 0..(size_of::<T>() as isize) {
+            unsafe {
+                if *p_first.offset(i) != *p_second.offset(i) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_syscall_get_sysvar() {
+        let config = Config::default();
+
+        let mut src_clock = create_filled_type::<Clock>(false);
+        src_clock.slot = 1;
+        src_clock.epoch_start_timestamp = 2;
+        src_clock.epoch = 3;
+        src_clock.leader_schedule_epoch = 4;
+        src_clock.unix_timestamp = 5;
+
+        let mut src_epochschedule = create_filled_type::<EpochSchedule>(false);
+        src_epochschedule.slots_per_epoch = 1;
+        src_epochschedule.leader_schedule_slot_offset = 2;
+        src_epochschedule.warmup = false;
+        src_epochschedule.first_normal_epoch = 3;
+        src_epochschedule.first_normal_slot = 4;
+
+        let mut src_fees = create_filled_type::<Fees>(false);
+        src_fees.fee_calculator = FeeCalculator {
+            lamports_per_signature: 1,
+        };
+
+        let mut src_rent = create_filled_type::<Rent>(false);
+        src_rent.lamports_per_byte_year = 1;
+        src_rent.exemption_threshold = 2.0;
+        src_rent.burn_percent = 3;
+
+        let mut src_rewards = create_filled_type::<EpochRewards>(false);
+        src_rewards.distribution_starting_block_height = 42;
+        src_rewards.num_partitions = 2;
+        src_rewards.parent_blockhash = Hash::new_from_array([3; 32]);
+        src_rewards.total_points = 4;
+        src_rewards.total_rewards = 100;
+        src_rewards.distributed_rewards = 10;
+        src_rewards.active = true;
+
+        let mut src_restart = create_filled_type::<LastRestartSlot>(false);
+        src_restart.last_restart_slot = 1;
+
+        let transaction_accounts = vec![
+            (
+                sysvar::clock::id(),
+                create_account_shared_data_for_test(&src_clock),
+            ),
+            (
+                sysvar::epoch_schedule::id(),
+                create_account_shared_data_for_test(&src_epochschedule),
+            ),
+            (
+                sysvar::fees::id(),
+                create_account_shared_data_for_test(&src_fees),
+            ),
+            (
+                sysvar::rent::id(),
+                create_account_shared_data_for_test(&src_rent),
+            ),
+            (
+                sysvar::epoch_rewards::id(),
+                create_account_shared_data_for_test(&src_rewards),
+            ),
+            (
+                sysvar::last_restart_slot::id(),
+                create_account_shared_data_for_test(&src_restart),
+            ),
+        ];
+        with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
+
+        // Test clock sysvar
+        {
+            let mut got_clock_obj = Clock::default();
+            let got_clock_obj_va = 0x100000000;
+
+            let mut got_clock_buf = vec![0; Clock::size_of()];
+            let got_clock_buf_va = 0x200000000;
+            let clock_id_va = 0x300000000;
+            let clock_id = Clock::id().to_bytes();
+
+            let mut memory_mapping = MemoryMapping::new(
+                vec![
+                    MemoryRegion::new_writable(bytes_of_mut(&mut got_clock_obj), got_clock_obj_va),
+                    MemoryRegion::new_writable(&mut got_clock_buf, got_clock_buf_va),
+                    MemoryRegion::new_readonly(&clock_id, clock_id_va),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap();
+
+            let result = SyscallGetClockSysvar::rust(
+                &mut invoke_context,
+                got_clock_obj_va,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+            assert_eq!(got_clock_obj, src_clock);
+
+            let mut clean_clock = create_filled_type::<Clock>(true);
+            clean_clock.slot = src_clock.slot;
+            clean_clock.epoch_start_timestamp = src_clock.epoch_start_timestamp;
+            clean_clock.epoch = src_clock.epoch;
+            clean_clock.leader_schedule_epoch = src_clock.leader_schedule_epoch;
+            clean_clock.unix_timestamp = src_clock.unix_timestamp;
+            assert!(are_bytes_equal(&got_clock_obj, &clean_clock));
+
+            let result = SyscallGetSysvar::rust(
+                &mut invoke_context,
+                clock_id_va,
+                got_clock_buf_va,
+                0,
+                Clock::size_of() as u64,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+
+            let clock_from_buf = bincode::deserialize::<Clock>(&got_clock_buf).unwrap();
+
+            assert_eq!(clock_from_buf, src_clock);
+            assert!(are_bytes_equal(&clock_from_buf, &clean_clock));
+        }
+
+        // Test epoch_schedule sysvar
+        {
+            let mut got_epochschedule_obj = EpochSchedule::default();
+            let got_epochschedule_obj_va = 0x100000000;
+
+            let mut got_epochschedule_buf = vec![0; EpochSchedule::size_of()];
+            let got_epochschedule_buf_va = 0x200000000;
+            let epochschedule_id_va = 0x300000000;
+            let epochschedule_id = EpochSchedule::id().to_bytes();
+
+            let mut memory_mapping = MemoryMapping::new(
+                vec![
+                    MemoryRegion::new_writable(
+                        bytes_of_mut(&mut got_epochschedule_obj),
+                        got_epochschedule_obj_va,
+                    ),
+                    MemoryRegion::new_writable(
+                        &mut got_epochschedule_buf,
+                        got_epochschedule_buf_va,
+                    ),
+                    MemoryRegion::new_readonly(&epochschedule_id, epochschedule_id_va),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap();
+
+            let result = SyscallGetEpochScheduleSysvar::rust(
+                &mut invoke_context,
+                got_epochschedule_obj_va,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+            assert_eq!(got_epochschedule_obj, src_epochschedule);
+
+            let mut clean_epochschedule = create_filled_type::<EpochSchedule>(true);
+            clean_epochschedule.slots_per_epoch = src_epochschedule.slots_per_epoch;
+            clean_epochschedule.leader_schedule_slot_offset =
+                src_epochschedule.leader_schedule_slot_offset;
+            clean_epochschedule.warmup = src_epochschedule.warmup;
+            clean_epochschedule.first_normal_epoch = src_epochschedule.first_normal_epoch;
+            clean_epochschedule.first_normal_slot = src_epochschedule.first_normal_slot;
+            assert!(are_bytes_equal(
+                &got_epochschedule_obj,
+                &clean_epochschedule
+            ));
+
+            let result = SyscallGetSysvar::rust(
+                &mut invoke_context,
+                epochschedule_id_va,
+                got_epochschedule_buf_va,
+                0,
+                EpochSchedule::size_of() as u64,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+
+            let epochschedule_from_buf =
+                bincode::deserialize::<EpochSchedule>(&got_epochschedule_buf).unwrap();
+
+            assert_eq!(epochschedule_from_buf, src_epochschedule);
+
+            // clone is to zero the alignment padding
+            assert!(are_bytes_equal(
+                &epochschedule_from_buf.clone(),
+                &clean_epochschedule
+            ));
+        }
+
+        // Test fees sysvar
+        {
+            let mut got_fees = Fees::default();
+            let got_fees_va = 0x100000000;
+
+            let mut memory_mapping = MemoryMapping::new(
+                vec![MemoryRegion::new_writable(
+                    bytes_of_mut(&mut got_fees),
+                    got_fees_va,
+                )],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap();
+
+            let result = SyscallGetFeesSysvar::rust(
+                &mut invoke_context,
+                got_fees_va,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+            assert_eq!(got_fees, src_fees);
+
+            let mut clean_fees = create_filled_type::<Fees>(true);
+            clean_fees.fee_calculator = src_fees.fee_calculator;
+            assert!(are_bytes_equal(&got_fees, &clean_fees));
+
+            // fees sysvar is not accessible via sol_get_sysvar so nothing further to test
+        }
+
+        // Test rent sysvar
+        {
+            let mut got_rent_obj = create_filled_type::<Rent>(true);
+            let got_rent_obj_va = 0x100000000;
+
+            let mut got_rent_buf = vec![0; Rent::size_of()];
+            let got_rent_buf_va = 0x200000000;
+            let rent_id_va = 0x300000000;
+            let rent_id = Rent::id().to_bytes();
+
+            let mut memory_mapping = MemoryMapping::new(
+                vec![
+                    MemoryRegion::new_writable(bytes_of_mut(&mut got_rent_obj), got_rent_obj_va),
+                    MemoryRegion::new_writable(&mut got_rent_buf, got_rent_buf_va),
+                    MemoryRegion::new_readonly(&rent_id, rent_id_va),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap();
+
+            let result = SyscallGetRentSysvar::rust(
+                &mut invoke_context,
+                got_rent_obj_va,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+            assert_eq!(got_rent_obj, src_rent);
+
+            let mut clean_rent = create_filled_type::<Rent>(true);
+            clean_rent.lamports_per_byte_year = src_rent.lamports_per_byte_year;
+            clean_rent.exemption_threshold = src_rent.exemption_threshold;
+            clean_rent.burn_percent = src_rent.burn_percent;
+            assert!(are_bytes_equal(&got_rent_obj, &clean_rent));
+
+            let result = SyscallGetSysvar::rust(
+                &mut invoke_context,
+                rent_id_va,
+                got_rent_buf_va,
+                0,
+                Rent::size_of() as u64,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+
+            let rent_from_buf = bincode::deserialize::<Rent>(&got_rent_buf).unwrap();
+
+            assert_eq!(rent_from_buf, src_rent);
+
+            // clone is to zero the alignment padding
+            assert!(are_bytes_equal(&rent_from_buf.clone(), &clean_rent));
+        }
+
+        // Test epoch rewards sysvar
+        {
+            let mut got_rewards_obj = create_filled_type::<EpochRewards>(true);
+            let got_rewards_obj_va = 0x100000000;
+
+            let mut got_rewards_buf = vec![0; EpochRewards::size_of()];
+            let got_rewards_buf_va = 0x200000000;
+            let rewards_id_va = 0x300000000;
+            let rewards_id = EpochRewards::id().to_bytes();
+
+            let mut memory_mapping = MemoryMapping::new(
+                vec![
+                    MemoryRegion::new_writable(
+                        bytes_of_mut(&mut got_rewards_obj),
+                        got_rewards_obj_va,
+                    ),
+                    MemoryRegion::new_writable(&mut got_rewards_buf, got_rewards_buf_va),
+                    MemoryRegion::new_readonly(&rewards_id, rewards_id_va),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap();
+
+            let result = SyscallGetEpochRewardsSysvar::rust(
+                &mut invoke_context,
+                got_rewards_obj_va,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+            assert_eq!(got_rewards_obj, src_rewards);
+
+            let mut clean_rewards = create_filled_type::<EpochRewards>(true);
+            clean_rewards.distribution_starting_block_height =
+                src_rewards.distribution_starting_block_height;
+            clean_rewards.num_partitions = src_rewards.num_partitions;
+            clean_rewards.parent_blockhash = src_rewards.parent_blockhash;
+            clean_rewards.total_points = src_rewards.total_points;
+            clean_rewards.total_rewards = src_rewards.total_rewards;
+            clean_rewards.distributed_rewards = src_rewards.distributed_rewards;
+            clean_rewards.active = src_rewards.active;
+            assert!(are_bytes_equal(&got_rewards_obj, &clean_rewards));
+
+            let result = SyscallGetSysvar::rust(
+                &mut invoke_context,
+                rewards_id_va,
+                got_rewards_buf_va,
+                0,
+                EpochRewards::size_of() as u64,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+
+            let rewards_from_buf = bincode::deserialize::<EpochRewards>(&got_rewards_buf).unwrap();
+
+            assert_eq!(rewards_from_buf, src_rewards);
+
+            // clone is to zero the alignment padding
+            assert!(are_bytes_equal(&rewards_from_buf.clone(), &clean_rewards));
+        }
+
+        // Test last restart slot sysvar
+        {
+            let mut got_restart_obj = LastRestartSlot::default();
+            let got_restart_obj_va = 0x100000000;
+
+            let mut got_restart_buf = vec![0; LastRestartSlot::size_of()];
+            let got_restart_buf_va = 0x200000000;
+            let restart_id_va = 0x300000000;
+            let restart_id = LastRestartSlot::id().to_bytes();
+
+            let mut memory_mapping = MemoryMapping::new(
+                vec![
+                    MemoryRegion::new_writable(
+                        bytes_of_mut(&mut got_restart_obj),
+                        got_restart_obj_va,
+                    ),
+                    MemoryRegion::new_writable(&mut got_restart_buf, got_restart_buf_va),
+                    MemoryRegion::new_readonly(&restart_id, restart_id_va),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap();
+
+            let result = SyscallGetLastRestartSlotSysvar::rust(
+                &mut invoke_context,
+                got_restart_obj_va,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+            assert_eq!(got_restart_obj, src_restart);
+
+            let mut clean_restart = create_filled_type::<LastRestartSlot>(true);
+            clean_restart.last_restart_slot = src_restart.last_restart_slot;
+            assert!(are_bytes_equal(&got_restart_obj, &clean_restart));
+
+            let result = SyscallGetSysvar::rust(
+                &mut invoke_context,
+                restart_id_va,
+                got_restart_buf_va,
+                0,
+                LastRestartSlot::size_of() as u64,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+
+            let restart_from_buf =
+                bincode::deserialize::<LastRestartSlot>(&got_restart_buf).unwrap();
+
+            assert_eq!(restart_from_buf, src_restart);
+            assert!(are_bytes_equal(&restart_from_buf, &clean_restart));
+        }
+    }
+
+    #[test_case(false; "partial")]
+    #[test_case(true; "full")]
+    fn test_syscall_get_stake_history(filled: bool) {
+        let config = Config::default();
+
+        let mut src_history = StakeHistory::default();
+
+        let epochs = if filled {
+            stake_history::MAX_ENTRIES + 1
+        } else {
+            stake_history::MAX_ENTRIES / 2
+        } as u64;
+
+        for epoch in 1..epochs {
+            src_history.add(
+                epoch,
+                StakeHistoryEntry {
+                    effective: epoch * 2,
+                    activating: epoch * 3,
+                    deactivating: epoch * 5,
+                },
+            );
+        }
+
+        let src_history = src_history;
+
+        let mut src_history_buf = vec![0; StakeHistory::size_of()];
+        bincode::serialize_into(&mut src_history_buf, &src_history).unwrap();
+
+        let transaction_accounts = vec![(
+            sysvar::stake_history::id(),
+            create_account_shared_data_for_test(&src_history),
+        )];
+        with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
+
+        {
+            let mut got_history_buf = vec![0; StakeHistory::size_of()];
+            let got_history_buf_va = 0x100000000;
+            let history_id_va = 0x200000000;
+            let history_id = StakeHistory::id().to_bytes();
+
+            let mut memory_mapping = MemoryMapping::new(
+                vec![
+                    MemoryRegion::new_writable(&mut got_history_buf, got_history_buf_va),
+                    MemoryRegion::new_readonly(&history_id, history_id_va),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap();
+
+            let result = SyscallGetSysvar::rust(
+                &mut invoke_context,
+                history_id_va,
+                got_history_buf_va,
+                0,
+                StakeHistory::size_of() as u64,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+
+            let history_from_buf = bincode::deserialize::<StakeHistory>(&got_history_buf).unwrap();
+            assert_eq!(history_from_buf, src_history);
+        }
+    }
+
+    #[test_case(false; "partial")]
+    #[test_case(true; "full")]
+    fn test_syscall_get_slot_hashes(filled: bool) {
+        let config = Config::default();
+
+        let mut src_hashes = SlotHashes::default();
+
+        let slots = if filled {
+            slot_hashes::MAX_ENTRIES + 1
+        } else {
+            slot_hashes::MAX_ENTRIES / 2
+        } as u64;
+
+        for slot in 1..slots {
+            src_hashes.add(slot, hashv(&[&slot.to_le_bytes()]));
+        }
+
+        let src_hashes = src_hashes;
+
+        let mut src_hashes_buf = vec![0; SlotHashes::size_of()];
+        bincode::serialize_into(&mut src_hashes_buf, &src_hashes).unwrap();
+
+        let transaction_accounts = vec![(
+            sysvar::slot_hashes::id(),
+            create_account_shared_data_for_test(&src_hashes),
+        )];
+        with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
+
+        {
+            let mut got_hashes_buf = vec![0; SlotHashes::size_of()];
+            let got_hashes_buf_va = 0x100000000;
+            let hashes_id_va = 0x200000000;
+            let hashes_id = SlotHashes::id().to_bytes();
+
+            let mut memory_mapping = MemoryMapping::new(
+                vec![
+                    MemoryRegion::new_writable(&mut got_hashes_buf, got_hashes_buf_va),
+                    MemoryRegion::new_readonly(&hashes_id, hashes_id_va),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap();
+
+            let result = SyscallGetSysvar::rust(
+                &mut invoke_context,
+                hashes_id_va,
+                got_hashes_buf_va,
+                0,
+                SlotHashes::size_of() as u64,
+                0,
+                &mut memory_mapping,
+            );
+            assert_eq!(result.unwrap(), 0);
+
+            let hashes_from_buf = bincode::deserialize::<SlotHashes>(&got_hashes_buf).unwrap();
+            assert_eq!(hashes_from_buf, src_hashes);
+        }
+    }
+
+    #[test]
+    fn test_syscall_get_sysvar_errors() {
+        let config = Config::default();
+
+        let mut src_clock = create_filled_type::<Clock>(false);
+        src_clock.slot = 1;
+        src_clock.epoch_start_timestamp = 2;
+        src_clock.epoch = 3;
+        src_clock.leader_schedule_epoch = 4;
+        src_clock.unix_timestamp = 5;
+
+        let clock_id_va = 0x100000000;
+        let clock_id = Clock::id().to_bytes();
+
+        let mut got_clock_buf_rw = vec![0; Clock::size_of()];
+        let got_clock_buf_rw_va = 0x200000000;
+
+        let got_clock_buf_ro = vec![0; Clock::size_of()];
+        let got_clock_buf_ro_va = 0x300000000;
+
+        let mut memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(&clock_id, clock_id_va),
+                MemoryRegion::new_writable(&mut got_clock_buf_rw, got_clock_buf_rw_va),
+                MemoryRegion::new_readonly(&got_clock_buf_ro, got_clock_buf_ro_va),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        let access_violation_err =
+            std::mem::discriminant(&EbpfError::AccessViolation(AccessType::Load, 0, 0, ""));
+
+        let got_clock_empty = vec![0; Clock::size_of()];
+
+        {
+            // start without the clock sysvar because we expect to hit specific errors before loading it
+            with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
+
+            // Abort: "Not all bytes in VM memory range `[sysvar_id, sysvar_id + 32)` are readable."
+            let e = SyscallGetSysvar::rust(
+                &mut invoke_context,
+                clock_id_va + 1,
+                got_clock_buf_rw_va,
+                0,
+                Clock::size_of() as u64,
+                0,
+                &mut memory_mapping,
+            )
+            .unwrap_err();
+
+            assert_eq!(
+                std::mem::discriminant(e.downcast_ref::<EbpfError>().unwrap()),
+                access_violation_err,
+            );
+            assert_eq!(got_clock_buf_rw, got_clock_empty);
+
+            // Abort: "Not all bytes in VM memory range `[var_addr, var_addr + length)` are writable."
+            let e = SyscallGetSysvar::rust(
+                &mut invoke_context,
+                clock_id_va,
+                got_clock_buf_rw_va + 1,
+                0,
+                Clock::size_of() as u64,
+                0,
+                &mut memory_mapping,
+            )
+            .unwrap_err();
+
+            assert_eq!(
+                std::mem::discriminant(e.downcast_ref::<EbpfError>().unwrap()),
+                access_violation_err,
+            );
+            assert_eq!(got_clock_buf_rw, got_clock_empty);
+
+            let e = SyscallGetSysvar::rust(
+                &mut invoke_context,
+                clock_id_va,
+                got_clock_buf_ro_va,
+                0,
+                Clock::size_of() as u64,
+                0,
+                &mut memory_mapping,
+            )
+            .unwrap_err();
+
+            assert_eq!(
+                std::mem::discriminant(e.downcast_ref::<EbpfError>().unwrap()),
+                access_violation_err,
+            );
+            assert_eq!(got_clock_buf_rw, got_clock_empty);
+
+            // Abort: "`offset + length` is not in `[0, 2^64)`."
+            let e = SyscallGetSysvar::rust(
+                &mut invoke_context,
+                clock_id_va,
+                got_clock_buf_rw_va,
+                u64::MAX - Clock::size_of() as u64 / 2,
+                Clock::size_of() as u64,
+                0,
+                &mut memory_mapping,
+            )
+            .unwrap_err();
+
+            assert_eq!(
+                *e.downcast_ref::<InstructionError>().unwrap(),
+                InstructionError::ArithmeticOverflow,
+            );
+            assert_eq!(got_clock_buf_rw, got_clock_empty);
+
+            // "`var_addr + length` is not in `[0, 2^64)`" is theoretically impossible to trigger
+            // because if the sum extended outside u64::MAX then it would not be writable and translate would fail
+
+            // "`2` if the sysvar data is not present in the Sysvar Cache."
+            let result = SyscallGetSysvar::rust(
+                &mut invoke_context,
+                clock_id_va,
+                got_clock_buf_rw_va,
+                0,
+                Clock::size_of() as u64,
+                0,
+                &mut memory_mapping,
+            )
+            .unwrap();
+
+            assert_eq!(result, 2);
+            assert_eq!(got_clock_buf_rw, got_clock_empty);
+        }
+
+        {
+            let transaction_accounts = vec![(
+                sysvar::clock::id(),
+                create_account_shared_data_for_test(&src_clock),
+            )];
+            with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
+
+            // "`1` if `offset + length` is greater than the length of the sysvar data."
+            let result = SyscallGetSysvar::rust(
+                &mut invoke_context,
+                clock_id_va,
+                got_clock_buf_rw_va,
+                1,
+                Clock::size_of() as u64,
+                0,
+                &mut memory_mapping,
+            )
+            .unwrap();
+
+            assert_eq!(result, 1);
+            assert_eq!(got_clock_buf_rw, got_clock_empty);
+
+            // and now lets succeed
+            SyscallGetSysvar::rust(
+                &mut invoke_context,
+                clock_id_va,
+                got_clock_buf_rw_va,
+                0,
+                Clock::size_of() as u64,
+                0,
+                &mut memory_mapping,
+            )
+            .unwrap();
+
+            let clock_from_buf = bincode::deserialize::<Clock>(&got_clock_buf_rw).unwrap();
+
+            assert_eq!(clock_from_buf, src_clock);
+        }
+    }
+
+    type BuiltinFunctionRustInterface<'a> = fn(
+        &mut InvokeContext<'a, 'a>,
+        u64,
+        u64,
+        u64,
+        u64,
+        u64,
+        &mut MemoryMapping,
+    ) -> Result<u64, Box<dyn std::error::Error>>;
+
+    fn call_program_address_common<'a, 'b: 'a>(
+        invoke_context: &'a mut InvokeContext<'b, 'b>,
+        seeds: &[&[u8]],
+        program_id: &Pubkey,
+        overlap_outputs: bool,
+        syscall: BuiltinFunctionRustInterface<'b>,
+    ) -> Result<(Pubkey, u8), Error> {
+        const SEEDS_VA: u64 = 0x100000000;
+        const PROGRAM_ID_VA: u64 = 0x200000000;
+        const ADDRESS_VA: u64 = 0x300000000;
+        const BUMP_SEED_VA: u64 = 0x400000000;
+        const SEED_VA: u64 = 0x500000000;
+
+        let config = Config::default();
+        let mut address = Pubkey::default();
+        let mut bump_seed = 0;
+        let mut regions = vec![
+            MemoryRegion::new_readonly(bytes_of(program_id), PROGRAM_ID_VA),
+            MemoryRegion::new_writable(bytes_of_mut(&mut address), ADDRESS_VA),
+            MemoryRegion::new_writable(bytes_of_mut(&mut bump_seed), BUMP_SEED_VA),
+        ];
+
+        let mut mock_slices = Vec::with_capacity(seeds.len());
+        for (i, seed) in seeds.iter().enumerate() {
+            let vm_addr = SEED_VA.saturating_add((i as u64).saturating_mul(0x100000000));
+            let mock_slice = MockSlice {
+                vm_addr,
+                len: seed.len(),
+            };
+            mock_slices.push(mock_slice);
+            regions.push(MemoryRegion::new_readonly(bytes_of_slice(seed), vm_addr));
+        }
+        regions.push(MemoryRegion::new_readonly(
+            bytes_of_slice(&mock_slices),
+            SEEDS_VA,
+        ));
+        let mut memory_mapping = MemoryMapping::new(regions, &config, SBPFVersion::V3).unwrap();
+
+        let result = syscall(
+            invoke_context,
+            SEEDS_VA,
+            seeds.len() as u64,
+            PROGRAM_ID_VA,
+            ADDRESS_VA,
+            if overlap_outputs {
+                ADDRESS_VA
+            } else {
+                BUMP_SEED_VA
+            },
+            &mut memory_mapping,
+        );
+        result.map(|_| (address, bump_seed))
+    }
+
+    fn create_program_address<'a>(
+        invoke_context: &mut InvokeContext<'a, 'a>,
+        seeds: &[&[u8]],
+        address: &Pubkey,
+    ) -> Result<Pubkey, Error> {
+        let (address, _) = call_program_address_common(
+            invoke_context,
+            seeds,
+            address,
+            false,
+            SyscallCreateProgramAddress::rust,
+        )?;
+        Ok(address)
+    }
+
+    fn try_find_program_address<'a>(
+        invoke_context: &mut InvokeContext<'a, 'a>,
+        seeds: &[&[u8]],
+        address: &Pubkey,
+    ) -> Result<(Pubkey, u8), Error> {
+        call_program_address_common(
+            invoke_context,
+            seeds,
+            address,
+            false,
+            SyscallTryFindProgramAddress::rust,
+        )
+    }
+
+    #[test]
+    fn test_set_and_get_return_data() {
+        const SRC_VA: u64 = 0x100000000;
+        const DST_VA: u64 = 0x200000000;
+        const PROGRAM_ID_VA: u64 = 0x300000000;
+        let data = vec![42; 24];
+        let mut data_buffer = vec![0; 16];
+        let mut id_buffer = vec![0; 32];
+
+        let config = Config::default();
+        let mut memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(&data, SRC_VA),
+                MemoryRegion::new_writable(&mut data_buffer, DST_VA),
+                MemoryRegion::new_writable(&mut id_buffer, PROGRAM_ID_VA),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+
+        let result = SyscallSetReturnData::rust(
+            &mut invoke_context,
+            SRC_VA,
+            data.len() as u64,
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_eq!(result.unwrap(), 0);
+
+        let result = SyscallGetReturnData::rust(
+            &mut invoke_context,
+            DST_VA,
+            data_buffer.len() as u64,
+            PROGRAM_ID_VA,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_eq!(result.unwrap() as usize, data.len());
+        assert_eq!(data.get(0..data_buffer.len()).unwrap(), data_buffer);
+        assert_eq!(id_buffer, program_id.to_bytes());
+
+        let result = SyscallGetReturnData::rust(
+            &mut invoke_context,
+            PROGRAM_ID_VA,
+            data_buffer.len() as u64,
+            PROGRAM_ID_VA,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        assert_matches!(
+            result,
+            Result::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::CopyOverlapping
+        );
+    }
+
+    #[test]
+    fn test_syscall_sol_get_processed_sibling_instruction() {
+        let transaction_accounts = (0..9)
+            .map(|_| {
+                (
+                    Pubkey::new_unique(),
+                    AccountSharedData::new(0, 0, &bpf_loader::id()),
+                )
+            })
+            .collect::<Vec<_>>();
+        let instruction_trace = [1, 2, 3, 2, 2, 3, 4, 3];
+        with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
+        for (index_in_trace, stack_height) in instruction_trace.into_iter().enumerate() {
+            while stack_height
+                <= invoke_context
+                    .transaction_context
+                    .get_instruction_stack_height()
+            {
+                invoke_context.transaction_context.pop().unwrap();
+            }
+            if stack_height
+                > invoke_context
+                    .transaction_context
+                    .get_instruction_stack_height()
+            {
+                let instruction_accounts = vec![InstructionAccount::new(
+                    index_in_trace.saturating_add(1) as IndexOfAccount,
+                    false,
+                    false,
+                )];
+                invoke_context
+                    .transaction_context
+                    .configure_next_instruction_for_tests(
+                        0,
+                        instruction_accounts,
+                        vec![index_in_trace as u8],
+                    )
+                    .unwrap();
+                invoke_context.transaction_context.push().unwrap();
+            }
+        }
+
+        let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
+
+        const VM_BASE_ADDRESS: u64 = 0x100000000;
+        const META_OFFSET: usize = 0;
+        const PROGRAM_ID_OFFSET: usize =
+            META_OFFSET + std::mem::size_of::<ProcessedSiblingInstruction>();
+        const DATA_OFFSET: usize = PROGRAM_ID_OFFSET + std::mem::size_of::<Pubkey>();
+        const ACCOUNTS_OFFSET: usize = DATA_OFFSET + 0x100;
+        const END_OFFSET: usize = ACCOUNTS_OFFSET + std::mem::size_of::<AccountInfo>() * 4;
+        let mut memory = [0u8; END_OFFSET];
+        let config = Config::default();
+        let mut memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_writable(&mut memory, VM_BASE_ADDRESS)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+        let processed_sibling_instruction =
+            unsafe { &mut *memory.as_mut_ptr().cast::<ProcessedSiblingInstruction>() };
+        processed_sibling_instruction.data_len = 1;
+        processed_sibling_instruction.accounts_len = 1;
+
+        invoke_context.mock_set_remaining(syscall_base_cost);
+        let result = SyscallGetProcessedSiblingInstruction::rust(
+            &mut invoke_context,
+            0,
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+            &mut memory_mapping,
+        );
+        assert_eq!(result.unwrap(), 1);
+        {
+            let program_id = translate_type::<Pubkey>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+                true,
+            )
+            .unwrap();
+            let data = translate_slice::<u8>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+                processed_sibling_instruction.data_len,
+                true,
+            )
+            .unwrap();
+            let accounts = translate_slice::<AccountMeta>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+                processed_sibling_instruction.accounts_len,
+                true,
+            )
+            .unwrap();
+            let transaction_context = &invoke_context.transaction_context;
+            assert_eq!(processed_sibling_instruction.data_len, 1);
+            assert_eq!(processed_sibling_instruction.accounts_len, 1);
+            assert_eq!(
+                program_id,
+                transaction_context.get_key_of_account_at_index(0).unwrap(),
+            );
+            assert_eq!(data, &[5]);
+            assert_eq!(
+                accounts,
+                &[AccountMeta {
+                    pubkey: *transaction_context.get_key_of_account_at_index(6).unwrap(),
+                    is_signer: false,
+                    is_writable: false
+                }]
+            );
+        }
+
+        invoke_context.mock_set_remaining(syscall_base_cost);
+        let result = SyscallGetProcessedSiblingInstruction::rust(
+            &mut invoke_context,
+            1,
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+            &mut memory_mapping,
+        );
+        assert_eq!(result.unwrap(), 0);
+
+        invoke_context.mock_set_remaining(syscall_base_cost);
+        let result = SyscallGetProcessedSiblingInstruction::rust(
+            &mut invoke_context,
+            0,
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            &mut memory_mapping,
+        );
+        assert_matches!(
+            result,
+            Result::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::CopyOverlapping
+        );
+    }
+
+    #[test]
+    fn test_create_program_address() {
+        // These tests duplicate the direct tests in solana_pubkey
+
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+        let address = bpf_loader_upgradeable::id();
+
+        let exceeded_seed = &[127; MAX_SEED_LEN + 1];
+        assert_matches!(
+            create_program_address(&mut invoke_context, &[exceeded_seed], &address),
+            Result::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::BadSeeds(PubkeyError::MaxSeedLengthExceeded)
+        );
+        assert_matches!(
+            create_program_address(
+                &mut invoke_context,
+                &[b"short_seed", exceeded_seed],
+                &address,
+            ),
+            Result::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::BadSeeds(PubkeyError::MaxSeedLengthExceeded)
+        );
+        let max_seed = &[0; MAX_SEED_LEN];
+        assert!(create_program_address(&mut invoke_context, &[max_seed], &address).is_ok());
+        let exceeded_seeds: &[&[u8]] = &[
+            &[1],
+            &[2],
+            &[3],
+            &[4],
+            &[5],
+            &[6],
+            &[7],
+            &[8],
+            &[9],
+            &[10],
+            &[11],
+            &[12],
+            &[13],
+            &[14],
+            &[15],
+            &[16],
+        ];
+        assert!(create_program_address(&mut invoke_context, exceeded_seeds, &address).is_ok());
+        let max_seeds: &[&[u8]] = &[
+            &[1],
+            &[2],
+            &[3],
+            &[4],
+            &[5],
+            &[6],
+            &[7],
+            &[8],
+            &[9],
+            &[10],
+            &[11],
+            &[12],
+            &[13],
+            &[14],
+            &[15],
+            &[16],
+            &[17],
+        ];
+        assert_matches!(
+            create_program_address(&mut invoke_context, max_seeds, &address),
+            Result::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::BadSeeds(PubkeyError::MaxSeedLengthExceeded)
+        );
+        assert_eq!(
+            create_program_address(&mut invoke_context, &[b"", &[1]], &address).unwrap(),
+            "BwqrghZA2htAcqq8dzP1WDAhTXYTYWj7CHxF5j7TDBAe"
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(
+            create_program_address(&mut invoke_context, &["☉".as_ref(), &[0]], &address).unwrap(),
+            "13yWmRpaTR4r5nAktwLqMpRNr28tnVUZw26rTvPSSB19"
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(
+            create_program_address(&mut invoke_context, &[b"Talking", b"Squirrels"], &address)
+                .unwrap(),
+            "2fnQrngrQT4SeLcdToJAD96phoEjNL2man2kfRLCASVk"
+                .parse()
+                .unwrap(),
+        );
+        let public_key = Pubkey::from_str("SeedPubey1111111111111111111111111111111111").unwrap();
+        assert_eq!(
+            create_program_address(&mut invoke_context, &[public_key.as_ref(), &[1]], &address)
+                .unwrap(),
+            "976ymqVnfE32QFe6NfGDctSvVa36LWnvYxhU6G2232YL"
+                .parse()
+                .unwrap(),
+        );
+        assert_ne!(
+            create_program_address(&mut invoke_context, &[b"Talking", b"Squirrels"], &address)
+                .unwrap(),
+            create_program_address(&mut invoke_context, &[b"Talking"], &address).unwrap(),
+        );
+        invoke_context.mock_set_remaining(0);
+        assert_matches!(
+            create_program_address(&mut invoke_context, &[b"", &[1]], &address),
+            Result::Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ComputationalBudgetExceeded
+        );
+    }
+
+    #[test]
+    fn test_find_program_address() {
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+        let cost = invoke_context
+            .get_execution_cost()
+            .create_program_address_units;
+        let address = bpf_loader_upgradeable::id();
+        let max_tries = 256; // one per seed
+
+        for _ in 0..1_000 {
+            let address = Pubkey::new_unique();
+            invoke_context.mock_set_remaining(cost * max_tries);
+            let (found_address, bump_seed) =
+                try_find_program_address(&mut invoke_context, &[b"Lil'", b"Bits"], &address)
+                    .unwrap();
+            assert_eq!(
+                found_address,
+                create_program_address(
+                    &mut invoke_context,
+                    &[b"Lil'", b"Bits", &[bump_seed]],
+                    &address,
+                )
+                .unwrap()
+            );
+        }
+
+        let seeds: &[&[u8]] = &[b""];
+        invoke_context.mock_set_remaining(cost * max_tries);
+        let (_, bump_seed) =
+            try_find_program_address(&mut invoke_context, seeds, &address).unwrap();
+        invoke_context.mock_set_remaining(cost * (max_tries - bump_seed as u64));
+        try_find_program_address(&mut invoke_context, seeds, &address).unwrap();
+        invoke_context.mock_set_remaining(cost * (max_tries - bump_seed as u64 - 1));
+        assert_matches!(
+            try_find_program_address(&mut invoke_context, seeds, &address),
+            Result::Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ComputationalBudgetExceeded
+        );
+
+        let exceeded_seed = &[127; MAX_SEED_LEN + 1];
+        invoke_context.mock_set_remaining(cost * (max_tries - 1));
+        assert_matches!(
+            try_find_program_address(&mut invoke_context, &[exceeded_seed], &address),
+            Result::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::BadSeeds(PubkeyError::MaxSeedLengthExceeded)
+        );
+        let exceeded_seeds: &[&[u8]] = &[
+            &[1],
+            &[2],
+            &[3],
+            &[4],
+            &[5],
+            &[6],
+            &[7],
+            &[8],
+            &[9],
+            &[10],
+            &[11],
+            &[12],
+            &[13],
+            &[14],
+            &[15],
+            &[16],
+            &[17],
+        ];
+        invoke_context.mock_set_remaining(cost * (max_tries - 1));
+        assert_matches!(
+            try_find_program_address(&mut invoke_context, exceeded_seeds, &address),
+            Result::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::BadSeeds(PubkeyError::MaxSeedLengthExceeded)
+        );
+
+        assert_matches!(
+            call_program_address_common(
+                &mut invoke_context,
+                seeds,
+                &address,
+                true,
+                SyscallTryFindProgramAddress::rust,
+            ),
+            Result::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::CopyOverlapping
+        );
+    }
+
+    #[test]
+    fn test_syscall_big_mod_exp() {
+        let config = Config::default();
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+
+        const VADDR_PARAMS: u64 = 0x100000000;
+        const MAX_LEN: u64 = 512;
+        const INV_LEN: u64 = MAX_LEN + 1;
+        let data: [u8; INV_LEN as usize] = [0; INV_LEN as usize];
+        const VADDR_DATA: u64 = 0x200000000;
+
+        let mut data_out: [u8; INV_LEN as usize] = [0; INV_LEN as usize];
+        const VADDR_OUT: u64 = 0x300000000;
+
+        // Test that SyscallBigModExp succeeds with the maximum param size
+        {
+            let params_max_len = BigModExpParams {
+                base: VADDR_DATA as *const u8,
+                base_len: MAX_LEN,
+                exponent: VADDR_DATA as *const u8,
+                exponent_len: MAX_LEN,
+                modulus: VADDR_DATA as *const u8,
+                modulus_len: MAX_LEN,
+            };
+
+            let mut memory_mapping = MemoryMapping::new(
+                vec![
+                    MemoryRegion::new_readonly(bytes_of(&params_max_len), VADDR_PARAMS),
+                    MemoryRegion::new_readonly(&data, VADDR_DATA),
+                    MemoryRegion::new_writable(&mut data_out, VADDR_OUT),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap();
+
+            let budget = invoke_context.get_execution_cost();
+            invoke_context.mock_set_remaining(
+                budget.syscall_base_cost
+                    + (MAX_LEN * MAX_LEN) / budget.big_modular_exponentiation_cost_divisor
+                    + budget.big_modular_exponentiation_base_cost,
+            );
+
+            let result = SyscallBigModExp::rust(
+                &mut invoke_context,
+                VADDR_PARAMS,
+                VADDR_OUT,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            );
+
+            assert_eq!(result.unwrap(), 0);
+        }
+
+        // Test that SyscallBigModExp fails when the maximum param size is exceeded
+        {
+            let params_inv_len = BigModExpParams {
+                base: VADDR_DATA as *const u8,
+                base_len: INV_LEN,
+                exponent: VADDR_DATA as *const u8,
+                exponent_len: INV_LEN,
+                modulus: VADDR_DATA as *const u8,
+                modulus_len: INV_LEN,
+            };
+
+            let mut memory_mapping = MemoryMapping::new(
+                vec![
+                    MemoryRegion::new_readonly(bytes_of(&params_inv_len), VADDR_PARAMS),
+                    MemoryRegion::new_readonly(&data, VADDR_DATA),
+                    MemoryRegion::new_writable(&mut data_out, VADDR_OUT),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap();
+
+            let budget = invoke_context.get_execution_cost();
+            invoke_context.mock_set_remaining(
+                budget.syscall_base_cost
+                    + (INV_LEN * INV_LEN) / budget.big_modular_exponentiation_cost_divisor
+                    + budget.big_modular_exponentiation_base_cost,
+            );
+
+            let result = SyscallBigModExp::rust(
+                &mut invoke_context,
+                VADDR_PARAMS,
+                VADDR_OUT,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            );
+
+            assert_matches!(
+                result,
+                Result::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::InvalidLength
+            );
+        }
+    }
+
+    #[test]
+    fn test_syscall_get_epoch_stake_total_stake() {
+        let config = Config::default();
+        let compute_cost = SVMTransactionExecutionCost::default();
+        let mut compute_budget = SVMTransactionExecutionBudget::default();
+        let sysvar_cache = Arc::<SysvarCache>::default();
+
+        const EXPECTED_TOTAL_STAKE: u64 = 200_000_000_000_000;
+
+        struct MockCallback {}
+        impl InvokeContextCallback for MockCallback {
+            fn get_epoch_stake(&self) -> u64 {
+                EXPECTED_TOTAL_STAKE
+            }
+            // Vote accounts are not needed for this test.
+        }
+
+        // Compute units, as specified by SIMD-0133.
+        // cu = syscall_base_cost
+        let expected_cus = compute_cost.syscall_base_cost;
+
+        // Set the compute budget to the expected CUs to ensure the syscall
+        // doesn't exceed the expected usage.
+        compute_budget.compute_unit_limit = expected_cus;
+
+        with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
+        let feature_set = SVMFeatureSet::default();
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
+        invoke_context.environment_config = EnvironmentConfig::new(
+            Hash::default(),
+            0,
+            &MockCallback {},
+            &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
+            &sysvar_cache,
+        );
+
+        let null_pointer_var = std::ptr::null::<Pubkey>() as u64;
+
+        let mut memory_mapping = MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap();
+
+        let result = SyscallGetEpochStake::rust(
+            &mut invoke_context,
+            null_pointer_var,
+            0,
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        )
+        .unwrap();
+
+        assert_eq!(result, EXPECTED_TOTAL_STAKE);
+    }
+
+    #[test]
+    fn test_syscall_get_epoch_stake_vote_account_stake() {
+        let config = Config::default();
+        let mut compute_budget = SVMTransactionExecutionBudget::default();
+        let compute_cost = SVMTransactionExecutionCost::default();
+        let sysvar_cache = Arc::<SysvarCache>::default();
+
+        const TARGET_VOTE_ADDRESS: Pubkey = Pubkey::new_from_array([2; 32]);
+        const EXPECTED_EPOCH_STAKE: u64 = 55_000_000_000;
+
+        struct MockCallback {}
+        impl InvokeContextCallback for MockCallback {
+            // Total stake is not needed for this test.
+            fn get_epoch_stake_for_vote_account(&self, vote_address: &Pubkey) -> u64 {
+                if *vote_address == TARGET_VOTE_ADDRESS {
+                    EXPECTED_EPOCH_STAKE
+                } else {
+                    0
+                }
+            }
+        }
+
+        // Compute units, as specified by SIMD-0133.
+        // cu = syscall_base_cost
+        //     + floor(32/cpi_bytes_per_unit)
+        //     + mem_op_base_cost
+        let expected_cus = compute_cost.syscall_base_cost
+            + (PUBKEY_BYTES as u64) / compute_cost.cpi_bytes_per_unit
+            + compute_cost.mem_op_base_cost;
+
+        // Set the compute budget to the expected CUs to ensure the syscall
+        // doesn't exceed the expected usage.
+        compute_budget.compute_unit_limit = expected_cus;
+
+        with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
+        let feature_set = SVMFeatureSet::default();
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
+        invoke_context.environment_config = EnvironmentConfig::new(
+            Hash::default(),
+            0,
+            &MockCallback {},
+            &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
+            &sysvar_cache,
+        );
+
+        {
+            // The syscall aborts the virtual machine if not all bytes in VM
+            // memory range `[vote_addr, vote_addr + 32)` are readable.
+            let vote_address_var = 0x100000000;
+
+            let mut memory_mapping = MemoryMapping::new(
+                vec![
+                    // Invalid read-only memory region.
+                    MemoryRegion::new_readonly(&[2; 31], vote_address_var),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap();
+
+            let result = SyscallGetEpochStake::rust(
+                &mut invoke_context,
+                vote_address_var,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            );
+
+            assert_access_violation!(result, vote_address_var, 32);
+        }
+
+        invoke_context.mock_set_remaining(compute_budget.compute_unit_limit);
+        {
+            // Otherwise, the syscall returns a `u64` integer representing the
+            // total active stake delegated to the vote account at the provided
+            // address.
+            let vote_address_var = 0x100000000;
+
+            let mut memory_mapping = MemoryMapping::new(
+                vec![MemoryRegion::new_readonly(
+                    bytes_of(&TARGET_VOTE_ADDRESS),
+                    vote_address_var,
+                )],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap();
+
+            let result = SyscallGetEpochStake::rust(
+                &mut invoke_context,
+                vote_address_var,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            )
+            .unwrap();
+
+            assert_eq!(result, EXPECTED_EPOCH_STAKE);
+        }
+
+        invoke_context.mock_set_remaining(compute_budget.compute_unit_limit);
+        {
+            // If the provided vote address corresponds to an account that is
+            // not a vote account or does not exist, the syscall will write
+            // `0` for active stake.
+            let vote_address_var = 0x100000000;
+            let not_a_vote_address = Pubkey::new_unique(); // Not a vote account.
+
+            let mut memory_mapping = MemoryMapping::new(
+                vec![MemoryRegion::new_readonly(
+                    bytes_of(&not_a_vote_address),
+                    vote_address_var,
+                )],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap();
+
+            let result = SyscallGetEpochStake::rust(
+                &mut invoke_context,
+                vote_address_var,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            )
+            .unwrap();
+
+            assert_eq!(result, 0); // `0` for active stake.
+        }
+    }
+
+    #[test]
+    fn test_check_type_assumptions() {
+        check_type_assumptions();
+    }
+
+    fn bytes_of<T>(val: &T) -> &[u8] {
+        let size = mem::size_of::<T>();
+        unsafe { slice::from_raw_parts(std::slice::from_ref(val).as_ptr().cast(), size) }
+    }
+
+    fn bytes_of_mut<T>(val: &mut T) -> &mut [u8] {
+        let size = mem::size_of::<T>();
+        unsafe { slice::from_raw_parts_mut(slice::from_mut(val).as_mut_ptr().cast(), size) }
+    }
+
+    fn bytes_of_slice<T>(val: &[T]) -> &[u8] {
+        let size = val.len().wrapping_mul(mem::size_of::<T>());
+        unsafe { slice::from_raw_parts(val.as_ptr().cast(), size) }
+    }
+
+    fn bytes_of_slice_mut<T>(val: &mut [T]) -> &mut [u8] {
+        let size = val.len().wrapping_mul(mem::size_of::<T>());
+        unsafe { slice::from_raw_parts_mut(val.as_mut_ptr().cast(), size) }
+    }
+
+    #[test]
+    fn test_address_is_aligned() {
+        for address in 0..std::mem::size_of::<u64>() {
+            assert_eq!(address_is_aligned::<u64>(address as u64), address == 0);
+        }
+    }
+
+    #[test_case(0x100000004, 0x100000004, &[0x00, 0x00, 0x00, 0x00])] // Intra region match
+    #[test_case(0x100000003, 0x100000004, &[0xFF, 0xFF, 0xFF, 0xFF])] // Intra region down
+    #[test_case(0x100000005, 0x100000004, &[0x01, 0x00, 0x00, 0x00])] // Intra region up
+    #[test_case(0x100000004, 0x200000004, &[0x00, 0x00, 0x00, 0x00])] // Inter region match
+    #[test_case(0x100000003, 0x200000004, &[0xFF, 0xFF, 0xFF, 0xFF])] // Inter region down
+    #[test_case(0x100000005, 0x200000004, &[0x01, 0x00, 0x00, 0x00])] // Inter region up
+    fn test_memcmp_success(src_a: u64, src_b: u64, expected_result: &[u8; 4]) {
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+        let mem = (0..12).collect::<Vec<u8>>();
+        let mut result_mem = vec![0; 4];
+        let config = Config::default();
+        let mut memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(&mem, 0x100000000),
+                MemoryRegion::new_readonly(&mem, 0x200000000),
+                MemoryRegion::new_writable(&mut result_mem, 0x300000000),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        let result = SyscallMemcmp::rust(
+            &mut invoke_context,
+            src_a,
+            src_b,
+            4,
+            0x300000000,
+            0,
+            &mut memory_mapping,
+        );
+        result.unwrap();
+        assert_eq!(result_mem, expected_result);
+    }
+
+    #[test_case(0x100000002, 0x100000004, 18245498089483734664)] // Down overlapping
+    #[test_case(0x100000004, 0x100000002, 6092969436446403628)] // Up overlapping
+    #[test_case(0x100000002, 0x100000006, 16598193894146733116)] // Down touching
+    #[test_case(0x100000006, 0x100000002, 8940776276357560353)] // Up touching
+    #[test_case(0x100000000, 0x100000008, 1288053912680171784)] // Down apart
+    #[test_case(0x100000008, 0x100000000, 4652742827052033592)] // Up apart
+    #[test_case(0x100000004, 0x200000004, 8833460765081683332)] // Down inter region
+    #[test_case(0x200000004, 0x100000004, 11837649335115988407)] // Up inter region
+    fn test_memmove_success(dst: u64, src: u64, expected_hash: u64) {
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+        let mut mem = (0..24).collect::<Vec<u8>>();
+        let config = Config::default();
+        let mut memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_writable(&mut mem[..12], 0x100000000),
+                MemoryRegion::new_writable(&mut mem[12..], 0x200000000),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        let result =
+            SyscallMemmove::rust(&mut invoke_context, dst, src, 4, 0, 0, &mut memory_mapping);
+        result.unwrap();
+        let mut hasher = DefaultHasher::new();
+        mem.hash(&mut hasher);
+        assert_eq!(hasher.finish(), expected_hash);
+    }
+
+    #[test_case(0x100000002, 0x00, 6070675560359421890)]
+    #[test_case(0x100000002, 0xFF, 3413209638111181029)]
+    fn test_memset_success(dst: u64, value: u64, expected_hash: u64) {
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+        let mut mem = (0..12).collect::<Vec<u8>>();
+        let config = Config::default();
+        let mut memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_writable(&mut mem, 0x100000000)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        let result = SyscallMemset::rust(
+            &mut invoke_context,
+            dst,
+            value,
+            4,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+        result.unwrap();
+        let mut hasher = DefaultHasher::new();
+        mem.hash(&mut hasher);
+        assert_eq!(hasher.finish(), expected_hash);
+    }
+
+    #[test_case(0x100000002, 0x100000004)] // Down overlapping
+    #[test_case(0x100000004, 0x100000002)] // Up overlapping
+    fn test_memcpy_overlapping(dst: u64, src: u64) {
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+        let mut mem = (0..12).collect::<Vec<u8>>();
+        let config = Config::default();
+        let mut memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_writable(&mut mem, 0x100000000)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        let result =
+            SyscallMemcpy::rust(&mut invoke_context, dst, src, 4, 0, 0, &mut memory_mapping);
+        assert_matches!(
+            result,
+            Result::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::CopyOverlapping
+        );
+    }
+
+    #[test_case(0xFFFFFFFFF, 0x100000006, 0xFFFFFFFFF)] // Dst lower bound
+    #[test_case(0x100000010, 0x100000006, 0x100000010)] // Dst upper bound
+    #[test_case(0x100000002, 0xFFFFFFFFF, 0xFFFFFFFFF)] // Src lower bound
+    #[test_case(0x100000002, 0x100000010, 0x100000010)] // Src upper bound
+    fn test_memops_access_violation(dst: u64, src: u64, fault_address: u64) {
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+        let mut mem = (0..12).collect::<Vec<u8>>();
+        let config = Config::default();
+        let mut memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_writable(&mut mem, 0x100000000)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        let result =
+            SyscallMemcpy::rust(&mut invoke_context, dst, src, 4, 0, 0, &mut memory_mapping);
+        assert_access_violation!(result, fault_address, 4);
+        let result =
+            SyscallMemmove::rust(&mut invoke_context, dst, src, 4, 0, 0, &mut memory_mapping);
+        assert_access_violation!(result, fault_address, 4);
+        let result =
+            SyscallMemcmp::rust(&mut invoke_context, dst, src, 4, 0, 0, &mut memory_mapping);
+        assert_access_violation!(result, fault_address, 4);
+    }
+
+    #[test_case(0xFFFFFFFFF)] // Dst lower bound
+    #[test_case(0x100000010)] // Dst upper bound
+    fn test_memset_access_violation(dst: u64) {
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+        let mut mem = (0..12).collect::<Vec<u8>>();
+        let config = Config::default();
+        let mut memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_writable(&mut mem, 0x100000000)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        let result = SyscallMemset::rust(&mut invoke_context, dst, 0, 4, 0, 0, &mut memory_mapping);
+        assert_access_violation!(result, dst, 4);
+    }
+
+    #[test]
+    fn test_memcmp_result_access_violation() {
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+        let mem = (0..12).collect::<Vec<u8>>();
+        let config = Config::default();
+        let mut memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_readonly(&mem, 0x100000000)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        let result = SyscallMemcmp::rust(
+            &mut invoke_context,
+            0x100000000,
+            0x100000000,
+            4,
+            0x100000000,
+            0,
+            &mut memory_mapping,
+        );
+        assert_access_violation!(result, 0x100000000, 4);
+    }
+}

--- a/syscalls/src/logging.rs
+++ b/syscalls/src/logging.rs
@@ -1,0 +1,157 @@
+use {
+    super::*, solana_program_runtime::memory::translate_vm_slice, solana_sbpf::vm::ContextObject,
+};
+
+declare_builtin_function!(
+    /// Log a user's info message
+    SyscallLog,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        addr: u64,
+        len: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let cost = invoke_context
+            .get_execution_cost()
+            .syscall_base_cost
+            .max(len);
+        consume_compute_meter(invoke_context, cost)?;
+
+        translate_string_and_do(
+            memory_mapping,
+            addr,
+            len,
+            invoke_context.get_check_aligned(),
+            &mut |string: &str| {
+                stable_log::program_log(&invoke_context.get_log_collector(), string);
+                Ok(0)
+            },
+        )?;
+        Ok(0)
+    }
+);
+
+declare_builtin_function!(
+    /// Log 5 64-bit values
+    SyscallLogU64,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        arg1: u64,
+        arg2: u64,
+        arg3: u64,
+        arg4: u64,
+        arg5: u64,
+        _memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let cost = invoke_context.get_execution_cost().log_64_units;
+        consume_compute_meter(invoke_context, cost)?;
+
+        stable_log::program_log(
+            &invoke_context.get_log_collector(),
+            &format!("{arg1:#x}, {arg2:#x}, {arg3:#x}, {arg4:#x}, {arg5:#x}"),
+        );
+        Ok(0)
+    }
+);
+
+declare_builtin_function!(
+    /// Log current compute consumption
+    SyscallLogBpfComputeUnits,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        _arg1: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        _memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let cost = invoke_context.get_execution_cost().syscall_base_cost;
+        consume_compute_meter(invoke_context, cost)?;
+
+        ic_logger_msg!(
+            invoke_context.get_log_collector(),
+            "Program consumption: {} units remaining",
+            invoke_context.get_remaining(),
+        );
+        Ok(0)
+    }
+);
+
+declare_builtin_function!(
+    /// Log a [`Pubkey`] as a base58 string
+    SyscallLogPubkey,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        pubkey_addr: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let cost = invoke_context.get_execution_cost().log_pubkey_units;
+        consume_compute_meter(invoke_context, cost)?;
+
+        let pubkey = translate_type::<Pubkey>(
+            memory_mapping,
+            pubkey_addr,
+            invoke_context.get_check_aligned(),
+        )?;
+        stable_log::program_log(&invoke_context.get_log_collector(), &pubkey.to_string());
+        Ok(0)
+    }
+);
+
+declare_builtin_function!(
+    /// Log data handling
+    SyscallLogData,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        addr: u64,
+        len: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let execution_cost = invoke_context.get_execution_cost();
+
+        consume_compute_meter(invoke_context, execution_cost.syscall_base_cost)?;
+
+        let untranslated_fields = translate_slice::<VmSlice<u8>>(
+            memory_mapping,
+            addr,
+            len,
+            invoke_context.get_check_aligned(),
+        )?;
+
+        consume_compute_meter(
+            invoke_context,
+            execution_cost
+                .syscall_base_cost
+                .saturating_mul(untranslated_fields.len() as u64),
+        )?;
+        consume_compute_meter(
+            invoke_context,
+            untranslated_fields
+                .iter()
+                .fold(0, |total, e| total.saturating_add(e.len())),
+        )?;
+
+        let mut fields = Vec::with_capacity(untranslated_fields.len());
+
+        for untranslated_field in untranslated_fields {
+            fields.push(translate_vm_slice(untranslated_field, memory_mapping, invoke_context.get_check_aligned())?);
+        }
+
+        let log_collector = invoke_context.get_log_collector();
+
+        stable_log::program_data(&log_collector, &fields);
+
+        Ok(0)
+    }
+);

--- a/syscalls/src/mem_ops.rs
+++ b/syscalls/src/mem_ops.rs
@@ -1,0 +1,195 @@
+use {super::*, crate::translate_mut};
+
+fn mem_op_consume(invoke_context: &mut InvokeContext, n: u64) -> Result<(), Error> {
+    let compute_cost = invoke_context.get_execution_cost();
+    let cost = compute_cost.mem_op_base_cost.max(
+        n.checked_div(compute_cost.cpi_bytes_per_unit)
+            .unwrap_or(u64::MAX),
+    );
+    consume_compute_meter(invoke_context, cost)
+}
+
+/// Check that two regions do not overlap.
+pub(crate) fn is_nonoverlapping<N>(src: N, src_len: N, dst: N, dst_len: N) -> bool
+where
+    N: Ord + num_traits::SaturatingSub,
+{
+    // If the absolute distance between the ptrs is at least as big as the size of the other,
+    // they do not overlap.
+    if src > dst {
+        src.saturating_sub(&dst) >= dst_len
+    } else {
+        dst.saturating_sub(&src) >= src_len
+    }
+}
+
+declare_builtin_function!(
+    /// memcpy
+    SyscallMemcpy,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        dst_addr: u64,
+        src_addr: u64,
+        n: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        mem_op_consume(invoke_context, n)?;
+
+        if !is_nonoverlapping(src_addr, n, dst_addr, n) {
+            return Err(SyscallError::CopyOverlapping.into());
+        }
+
+        // host addresses can overlap so we always invoke memmove
+        memmove(invoke_context, dst_addr, src_addr, n, memory_mapping)
+    }
+);
+
+declare_builtin_function!(
+    /// memmove
+    SyscallMemmove,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        dst_addr: u64,
+        src_addr: u64,
+        n: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        mem_op_consume(invoke_context, n)?;
+
+        memmove(invoke_context, dst_addr, src_addr, n, memory_mapping)
+    }
+);
+
+declare_builtin_function!(
+    /// memcmp
+    SyscallMemcmp,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        s1_addr: u64,
+        s2_addr: u64,
+        n: u64,
+        cmp_result_addr: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        mem_op_consume(invoke_context, n)?;
+
+        let s1 = translate_slice::<u8>(
+            memory_mapping,
+            s1_addr,
+            n,
+            invoke_context.get_check_aligned(),
+        )?;
+        let s2 = translate_slice::<u8>(
+            memory_mapping,
+            s2_addr,
+            n,
+            invoke_context.get_check_aligned(),
+        )?;
+
+        debug_assert_eq!(s1.len(), n as usize);
+        debug_assert_eq!(s2.len(), n as usize);
+        // Safety:
+        // memcmp is marked unsafe since it assumes that the inputs are at least
+        // `n` bytes long. `s1` and `s2` are guaranteed to be exactly `n` bytes
+        // long because `translate_slice` would have failed otherwise.
+        let result = unsafe { memcmp(s1, s2, n as usize) };
+
+        translate_mut!(
+            memory_mapping,
+            invoke_context.get_check_aligned(),
+            let cmp_result_ref_mut: &mut i32 = map(cmp_result_addr)?;
+        );
+        *cmp_result_ref_mut = result;
+
+        Ok(0)
+    }
+);
+
+declare_builtin_function!(
+    /// memset
+    SyscallMemset,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        dst_addr: u64,
+        c: u64,
+        n: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        mem_op_consume(invoke_context, n)?;
+
+        translate_mut!(
+            memory_mapping,
+            invoke_context.get_check_aligned(),
+            let s: &mut [u8] = map(dst_addr, n)?;
+        );
+        s.fill(c as u8);
+        Ok(0)
+    }
+);
+
+fn memmove(
+    invoke_context: &mut InvokeContext,
+    dst_addr: u64,
+    src_addr: u64,
+    n: u64,
+    memory_mapping: &mut MemoryMapping,
+) -> Result<u64, Error> {
+    translate_mut!(
+        memory_mapping,
+        invoke_context.get_check_aligned(),
+        let dst_ref_mut: &mut [u8] = map(dst_addr, n)?;
+    );
+    let dst_ptr = dst_ref_mut.as_mut_ptr();
+    let src_ptr = translate_slice::<u8>(
+        memory_mapping,
+        src_addr,
+        n,
+        invoke_context.get_check_aligned(),
+    )?
+    .as_ptr();
+
+    unsafe { std::ptr::copy(src_ptr, dst_ptr, n as usize) };
+    Ok(0)
+}
+
+// Marked unsafe since it assumes that the slices are at least `n` bytes long.
+unsafe fn memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
+    for i in 0..n {
+        let a = *s1.get_unchecked(i);
+        let b = *s2.get_unchecked(i);
+        if a != b {
+            return (a as i32).saturating_sub(b as i32);
+        };
+    }
+
+    0
+}
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+#[allow(clippy::arithmetic_side_effects)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_nonoverlapping() {
+        for dst in 0..8 {
+            assert!(is_nonoverlapping(10, 3, dst, 3));
+        }
+        for dst in 8..13 {
+            assert!(!is_nonoverlapping(10, 3, dst, 3));
+        }
+        for dst in 13..20 {
+            assert!(is_nonoverlapping(10, 3, dst, 3));
+        }
+        assert!(is_nonoverlapping::<u8>(255, 3, 254, 1));
+        assert!(!is_nonoverlapping::<u8>(255, 2, 254, 3));
+    }
+}

--- a/syscalls/src/sysvar.rs
+++ b/syscalls/src/sysvar.rs
@@ -1,0 +1,255 @@
+use {
+    super::*, crate::translate_mut,
+    solana_program_runtime::execution_budget::SVMTransactionExecutionCost, solana_sbpf::ebpf,
+};
+
+fn get_sysvar<T: std::fmt::Debug + SysvarSerialize + Clone>(
+    sysvar: Result<Arc<T>, InstructionError>,
+    var_addr: u64,
+    check_aligned: bool,
+    memory_mapping: &mut MemoryMapping,
+    invoke_context: &mut InvokeContext,
+) -> Result<u64, Error> {
+    consume_compute_meter(
+        invoke_context,
+        invoke_context
+            .get_execution_cost()
+            .sysvar_base_cost
+            .saturating_add(size_of::<T>() as u64),
+    )?;
+
+    if var_addr >= ebpf::MM_INPUT_START
+        && invoke_context
+            .get_feature_set()
+            .stricter_abi_and_runtime_constraints
+    {
+        return Err(SyscallError::InvalidPointer.into());
+    }
+    translate_mut!(
+        memory_mapping,
+        check_aligned,
+        let var: &mut T = map(var_addr)?;
+    );
+
+    // this clone looks unnecessary now, but it exists to zero out trailing alignment bytes
+    // it is unclear whether this should ever matter
+    // but there are tests using MemoryMapping that expect to see this
+    // we preserve the previous behavior out of an abundance of caution
+    let sysvar: Arc<T> = sysvar?;
+    *var = T::clone(sysvar.as_ref());
+
+    Ok(SUCCESS)
+}
+
+declare_builtin_function!(
+    /// Get a Clock sysvar
+    SyscallGetClockSysvar,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        var_addr: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        get_sysvar(
+            invoke_context.get_sysvar_cache().get_clock(),
+            var_addr,
+            invoke_context.get_check_aligned(),
+            memory_mapping,
+            invoke_context,
+        )
+    }
+);
+
+declare_builtin_function!(
+    /// Get a EpochSchedule sysvar
+    SyscallGetEpochScheduleSysvar,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        var_addr: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        get_sysvar(
+            invoke_context.get_sysvar_cache().get_epoch_schedule(),
+            var_addr,
+            invoke_context.get_check_aligned(),
+            memory_mapping,
+            invoke_context,
+        )
+    }
+);
+
+declare_builtin_function!(
+    /// Get a EpochRewards sysvar
+    SyscallGetEpochRewardsSysvar,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        var_addr: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        get_sysvar(
+            invoke_context.get_sysvar_cache().get_epoch_rewards(),
+            var_addr,
+            invoke_context.get_check_aligned(),
+            memory_mapping,
+            invoke_context,
+        )
+    }
+);
+
+declare_builtin_function!(
+    /// Get a Fees sysvar
+    SyscallGetFeesSysvar,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        var_addr: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        #[allow(deprecated)]
+        {
+            get_sysvar(
+                invoke_context.get_sysvar_cache().get_fees(),
+                var_addr,
+                invoke_context.get_check_aligned(),
+                memory_mapping,
+                invoke_context,
+            )
+        }
+    }
+);
+
+declare_builtin_function!(
+    /// Get a Rent sysvar
+    SyscallGetRentSysvar,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        var_addr: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        get_sysvar(
+            invoke_context.get_sysvar_cache().get_rent(),
+            var_addr,
+            invoke_context.get_check_aligned(),
+            memory_mapping,
+            invoke_context,
+        )
+    }
+);
+
+declare_builtin_function!(
+    /// Get a Last Restart Slot sysvar
+    SyscallGetLastRestartSlotSysvar,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        var_addr: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        get_sysvar(
+            invoke_context.get_sysvar_cache().get_last_restart_slot(),
+            var_addr,
+            invoke_context.get_check_aligned(),
+            memory_mapping,
+            invoke_context,
+        )
+    }
+);
+
+const SYSVAR_NOT_FOUND: u64 = 2;
+const OFFSET_LENGTH_EXCEEDS_SYSVAR: u64 = 1;
+
+// quoted language from SIMD0127
+// because this syscall can both return error codes and abort, well-ordered error checking is crucial
+declare_builtin_function!(
+    /// Get a slice of a Sysvar in-memory representation
+    SyscallGetSysvar,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        sysvar_id_addr: u64,
+        var_addr: u64,
+        offset: u64,
+        length: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let check_aligned = invoke_context.get_check_aligned();
+        let SVMTransactionExecutionCost {
+            sysvar_base_cost,
+            cpi_bytes_per_unit,
+            mem_op_base_cost,
+            ..
+        } = *invoke_context.get_execution_cost();
+
+        // Abort: "Compute budget is exceeded."
+        let sysvar_id_cost = 32_u64.checked_div(cpi_bytes_per_unit).unwrap_or(0);
+        let sysvar_buf_cost = length.checked_div(cpi_bytes_per_unit).unwrap_or(0);
+        consume_compute_meter(
+            invoke_context,
+            sysvar_base_cost
+                .saturating_add(sysvar_id_cost)
+                .saturating_add(std::cmp::max(sysvar_buf_cost, mem_op_base_cost)),
+        )?;
+
+        if var_addr >= ebpf::MM_INPUT_START
+            && invoke_context
+                .get_feature_set()
+                .stricter_abi_and_runtime_constraints
+        {
+            return Err(SyscallError::InvalidPointer.into());
+        }
+        // Abort: "Not all bytes in VM memory range `[var_addr, var_addr + length)` are writable."
+        translate_mut!(
+            memory_mapping,
+            check_aligned,
+            let var: &mut [u8] = map(var_addr, length)?;
+        );
+
+        // Abort: "Not all bytes in VM memory range `[sysvar_id, sysvar_id + 32)` are readable."
+        let sysvar_id = translate_type::<Pubkey>(memory_mapping, sysvar_id_addr, check_aligned)?;
+
+        // Abort: "`offset + length` is not in `[0, 2^64)`."
+        let offset_length = offset
+            .checked_add(length)
+            .ok_or(InstructionError::ArithmeticOverflow)?;
+
+        // Abort: "`var_addr + length` is not in `[0, 2^64)`."
+        let _ = var_addr
+            .checked_add(length)
+            .ok_or(InstructionError::ArithmeticOverflow)?;
+
+        let cache = invoke_context.get_sysvar_cache();
+
+        // "`2` if the sysvar data is not present in the Sysvar Cache."
+        let Some(ref sysvar_buf) = cache.sysvar_id_to_buffer(sysvar_id) else { return Ok(SYSVAR_NOT_FOUND) };
+
+        // "`1` if `offset + length` is greater than the length of the sysvar data."
+        if let Some(sysvar_slice) = sysvar_buf.get(offset as usize..offset_length as usize) {
+            var.copy_from_slice(sysvar_slice);
+        } else {
+            return Ok(OFFSET_LENGTH_EXCEEDS_SYSVAR);
+        }
+
+        Ok(SUCCESS)
+    }
+);


### PR DESCRIPTION
Summary:
- Bump the SVM fork to solana-sbpf 0.14.4 for the newer sBPF v3 ELF layout.
- Patch the loader/syscall crates locally so loader-v4 uses the same parser.
- Update the affected API call sites for the solana-sbpf 0.14 MemoryMapping/SBPFVersion changes.

Validation:
- env RUSTFLAGS=-Awarnings cargo check -p solana-bpf-loader-program --features agave-unstable-api
- env RUSTFLAGS=-Awarnings cargo check -p solana-loader-v4-program --features agave-unstable-api
- env RUSTFLAGS=-Awarnings cargo check -p solana-svm