### PR TITLE
featr: make outbox program instruction privileged

### DIFF
--- a/svm/src/access_permissions.rs
+++ b/svm/src/access_permissions.rs
@@ -10,7 +10,11 @@ const MAGIC_PROGRAM_ID: Pubkey =
     Pubkey::from_str_const("Magic11111111111111111111111111111111111111");
 const POST_DELEGATION_ACTION_EXECUTOR_PROGRAM_ID: Pubkey =
     Pubkey::from_str_const("PostAct111111111111111111111111111111111111");
+pub const OUTBOX_INTENT_PROGRAM_ID: Pubkey =
+    Pubkey::from_str_const("outboxintent1111111111111111111111111111111");
+
 const PRIVILEGED_MAGIC_DISCRIMINANTS: [u32; 13] = [0, 3, 4, 8, 9, 16, 17, 18, 19, 20, 21, 22, 24];
+const PRIVILEGED_OUTBOX_INTENT_DISCRIMINANTS: [u32; 2] = [0, 1];
 const CLONE_ACCOUNT_DISCRIMINANT: u32 = 16;
 const CLONE_ACCOUNT_CONTINUE_DISCRIMINANT: u32 = 18;
 const CLONED_ACCOUNT_INSTRUCTION_ACCOUNT_INDEX: usize = 1;
@@ -121,13 +125,21 @@ fn privileged_access(message: &impl SVMMessage) -> PrivilegedAccess {
         if *program == loader_v4::ID {
             continue;
         }
-        if *program != MAGIC_PROGRAM_ID {
-            return PrivilegedAccess::None;
-        }
 
-        let discriminant = instruction_discriminant(&instruction).unwrap_or(u32::MAX);
-        if !PRIVILEGED_MAGIC_DISCRIMINANTS.contains(&discriminant) {
-            return PrivilegedAccess::None;
+        match *program {
+            MAGIC_PROGRAM_ID => {
+                let discriminant = instruction_discriminant(&instruction).unwrap_or(u32::MAX);
+                if !PRIVILEGED_MAGIC_DISCRIMINANTS.contains(&discriminant) {
+                    return PrivilegedAccess::None;
+                }
+            }
+            OUTBOX_INTENT_PROGRAM_ID => {
+                let discriminant = instruction_discriminant(&instruction).unwrap_or(u32::MAX);
+                if !PRIVILEGED_OUTBOX_INTENT_DISCRIMINANTS.contains(&discriminant) {
+                    return PrivilegedAccess::None;
+                }
+            }
+            _ => return PrivilegedAccess::None,
         }
     }
     PrivilegedAccess::Full

--- a/svm/src/access_permissions.rs
+++ b/svm/src/access_permissions.rs
@@ -213,6 +213,10 @@ mod tests {
         std::collections::{HashMap, HashSet},
     };
 
+    const ACCEPT_SCHEDULE_COMMITS_DISCRIMINANT: u32 = PRIVILEGED_OUTBOX_INTENT_DISCRIMINANTS[0];
+    const SCHEDULED_COMMIT_SENT_DISCRIMINANT: u32 = PRIVILEGED_OUTBOX_INTENT_DISCRIMINANTS[1];
+    const UNLISTED_OUTBOX_INTENT_DISCRIMINANT: u32 = 2;
+
     fn privileged_account() -> AccountSharedData {
         let mut account = AccountSharedData::default();
         account.set_privileged(true);
@@ -486,6 +490,93 @@ mod tests {
         let writable = Pubkey::new_unique();
         let mut tx = executed_transaction(payer, writable);
         let message = message(MAGIC_PROGRAM_ID, 1u32.to_le_bytes().to_vec());
+
+        tx.validate_accounts_access(&message);
+
+        assert_eq!(
+            tx.execution_details.status,
+            Err(TransactionError::InvalidWritableAccount)
+        );
+    }
+
+    #[test]
+    fn privileged_payer_allows_outbox_intent_control_instruction() {
+        let payer = Pubkey::new_unique();
+        let writable = Pubkey::new_unique();
+        let mut tx = executed_transaction(payer, writable);
+        let message = message(
+            OUTBOX_INTENT_PROGRAM_ID,
+            ACCEPT_SCHEDULE_COMMITS_DISCRIMINANT.to_le_bytes().to_vec(),
+        );
+
+        tx.validate_accounts_access(&message);
+
+        assert_eq!(tx.execution_details.status, Ok(()));
+    }
+
+    #[test]
+    fn privileged_payer_allows_outbox_intent_second_control_instruction() {
+        let payer = Pubkey::new_unique();
+        let writable = Pubkey::new_unique();
+        let mut tx = executed_transaction(payer, writable);
+        let message = message(
+            OUTBOX_INTENT_PROGRAM_ID,
+            SCHEDULED_COMMIT_SENT_DISCRIMINANT.to_le_bytes().to_vec(),
+        );
+
+        tx.validate_accounts_access(&message);
+
+        assert_eq!(tx.execution_details.status, Ok(()));
+    }
+
+    #[test]
+    fn privileged_payer_rejects_unlisted_outbox_intent_instruction() {
+        let payer = Pubkey::new_unique();
+        let writable = Pubkey::new_unique();
+        let mut tx = executed_transaction(payer, writable);
+        let message = message(
+            OUTBOX_INTENT_PROGRAM_ID,
+            UNLISTED_OUTBOX_INTENT_DISCRIMINANT.to_le_bytes().to_vec(),
+        );
+
+        tx.validate_accounts_access(&message);
+
+        assert_eq!(
+            tx.execution_details.status,
+            Err(TransactionError::InvalidWritableAccount)
+        );
+    }
+
+    #[test]
+    fn privileged_payer_allows_mixed_magic_and_outbox_intent_instructions() {
+        let payer = Pubkey::new_unique();
+        let writable = Pubkey::new_unique();
+        let mut tx = executed_transaction(payer, writable);
+        let message = message_with_programs(vec![
+            (MAGIC_PROGRAM_ID, 8u32.to_le_bytes().to_vec()),
+            (
+                OUTBOX_INTENT_PROGRAM_ID,
+                ACCEPT_SCHEDULE_COMMITS_DISCRIMINANT.to_le_bytes().to_vec(),
+            ),
+        ]);
+
+        tx.validate_accounts_access(&message);
+
+        assert_eq!(tx.execution_details.status, Ok(()));
+    }
+
+    #[test]
+    fn privileged_payer_rejects_mixed_magic_and_unlisted_outbox_intent_instruction() {
+        let payer = Pubkey::new_unique();
+        let writable = Pubkey::new_unique();
+        let mut tx = executed_transaction(payer, writable);
+        let message = message_with_programs(vec![
+            (MAGIC_PROGRAM_ID, 8u32.to_le_bytes().to_vec()),
+            (
+                OUTBOX_INTENT_PROGRAM_ID,
+                UNLISTED_OUTBOX_INTENT_DISCRIMINANT.to_le_bytes().to_vec(),
+            ),
+        ]);
 
         tx.validate_accounts_access(&message);
 


### PR DESCRIPTION
This [PR](https://github.com/magicblock-labs/magicblock-validator/pull/1430). in magicblock-validator separates outbox logic from magic-program into separate program. To allow creation of ER accounts using validator keypair we need to make outbox program & discriminants privileged in svm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for authorized Outbox Intent operations in privileged access validation.
  * Added a publicly available identifier for the Outbox Intent program.

* **Bug Fixes**
  * Improved validation to reject unauthorized instructions while accepting approved operations from supported programs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->